### PR TITLE
Add target validation. Add proxy entities for virtual applications.

### DIFF
--- a/prometurbo/pkg/discovery/constant/constants.go
+++ b/prometurbo/pkg/discovery/constant/constants.go
@@ -21,10 +21,12 @@ const (
 	LatencyCap = 500.0 //millisec
 
 	// The default namespace of entity property
-	DefaultPropertyNamespace string = "DEFAULT"
+	DefaultPropertyNamespace = "DEFAULT"
 
 	// The attribute used for stitching with other probes (e.g., prometurbo) with app and vapp
 	StitchingAttr string = "IP"
+
+	VAppPrefix = "vApp-"
 )
 
 var EntityTypeMap = map[int32]proto.EntityDTO_EntityType{

--- a/prometurbo/pkg/discovery/discovery_client_test.go
+++ b/prometurbo/pkg/discovery/discovery_client_test.go
@@ -123,6 +123,10 @@ func (m *mockExporter) Query() ([]*exporter.EntityMetric, error) {
 	return m.metrics, m.err
 }
 
+func (m *mockExporter) Validate() bool {
+	return true
+}
+
 func newMetric(ip string, tpsUsed, latUsed float64, entityType int32) *exporter.EntityMetric {
 	m := map[string]float64{
 		constant.TPS:     tpsUsed,

--- a/prometurbo/pkg/p8s_tap_service.go
+++ b/prometurbo/pkg/p8s_tap_service.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 )
 
 type disconnectFromTurboFunc func()
@@ -33,10 +32,6 @@ func NewP8sTAPService(args *conf.PrometurboArgs) (*P8sTAPService, error) {
 
 func (p *P8sTAPService) Start() {
 	glog.V(0).Infof("Starting prometheus TAP service...")
-
-	// Before running service, wait for the exporter to start up
-	// TODO: Check the readiness of the exporter
-	time.Sleep(5 * time.Second)
 
 	// Disconnect from Turbo server when Kubeturbo is shutdown
 	handleExit(func() { p.tapService.DisconnectFromTurbo() })

--- a/prometurbo/pkg/registration/supply_chain_factory.go
+++ b/prometurbo/pkg/registration/supply_chain_factory.go
@@ -29,7 +29,12 @@ func (f *SupplyChainFactory) CreateSupplyChain() ([]*proto.TemplateDTO, error) {
 		return nil, err
 	}
 
-	return supplychain.NewSupplyChainBuilder().Top(appNode).
+	vAppNode, err := f.buildVAppSupplyBuilder()
+	if err != nil {
+		return nil, err
+	}
+
+	return supplychain.NewSupplyChainBuilder().Top(vAppNode).Entity(appNode).
 		Create()
 }
 
@@ -37,6 +42,18 @@ func (f *SupplyChainFactory) buildAppSupplyBuilder() (*proto.TemplateDTO, error)
 	builder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_APPLICATION).
 		Sells(transactionTemplateComm).
 		Sells(respTimeTemplateComm)
+	builder.SetPriority(-1)
+	builder.SetTemplateType(proto.TemplateDTO_BASE)
+	//builder.SetTemplateType(proto.TemplateDTO_EXTENSION)
+
+	return builder.Create()
+}
+
+func (f *SupplyChainFactory) buildVAppSupplyBuilder() (*proto.TemplateDTO, error) {
+	builder := supplychain.NewSupplyChainNodeBuilder(proto.EntityDTO_VIRTUAL_APPLICATION).
+		Provider(proto.EntityDTO_APPLICATION, proto.Provider_LAYERED_OVER).
+		Buys(transactionTemplateComm).
+		Buys(respTimeTemplateComm)
 	builder.SetPriority(-1)
 	builder.SetTemplateType(proto.TemplateDTO_BASE)
 	//builder.SetTemplateType(proto.TemplateDTO_EXTENSION)


### PR DESCRIPTION
- Add target validation so that validation fails if all exporters have no response.

- Add proxy entities for virtual applications so in the server side, the vApp commodities can be updated with usage values after stitching with the commodities from Kubeturbo.