### PR TITLE
Set proxy entities as not monitored

### DIFF
--- a/prometurbo/pkg/discovery/dtofactory/entity_builder.go
+++ b/prometurbo/pkg/discovery/dtofactory/entity_builder.go
@@ -109,6 +109,7 @@ func (b *entityBuilder) createConsumerEntity(provider *proto.EntityDTO, ip strin
 			BuysCommodities(commodities).
 			WithProperty(getEntityProperty(constant.VAppPrefix + ip)).
 			ReplacedBy(getReplacementMetaData(vAppType, commTypes, true)).
+			Monitored(false).
 			Create()
 
 		if err != nil {
@@ -186,6 +187,7 @@ func (b *entityBuilder) createEntityDto() (*proto.EntityDTO, error) {
 		SellsCommodities(commodities).
 		WithProperty(getEntityProperty(ip)).
 		ReplacedBy(getReplacementMetaData(entityType, commTypes, false)).
+		Monitored(false).
 		Create()
 
 	if err != nil {


### PR DESCRIPTION
Prometurbo creates entities as proxy for stitching in server side. We don't want these proxy to participate in market analysis so they are flagged as not monitored.