### PR TITLE
Support adding multiple prometurbo targets

### DIFF
--- a/prometurbo/pkg/discovery/discovery_client.go
+++ b/prometurbo/pkg/discovery/discovery_client.go
@@ -44,7 +44,7 @@ func (d *P8sDiscoveryClient) GetAccountValues() *probe.TurboTargetInfo {
 		scopeVal,
 	}
 
-	targetInfo := probe.NewTurboTargetInfoBuilder(registration.ProbeCategory, registration.TargetType,
+	targetInfo := probe.NewTurboTargetInfoBuilder(registration.ProbeCategory, registration.TargetType(d.targetAddr),
 		registration.TargetIdField, accountValues).Create()
 
 	return targetInfo
@@ -52,7 +52,6 @@ func (d *P8sDiscoveryClient) GetAccountValues() *probe.TurboTargetInfo {
 
 // Validate the Target
 func (d *P8sDiscoveryClient) Validate(accountValues []*proto.AccountValue) (*proto.ValidationResponse, error) {
-	// TODO: Add logic for validation
 	validationResponse := &proto.ValidationResponse{}
 
 	// Validation fails if no exporter responses

--- a/prometurbo/pkg/p8s_tap_service.go
+++ b/prometurbo/pkg/p8s_tap_service.go
@@ -68,7 +68,7 @@ func createTAPService(args *conf.PrometurboArgs) (*service.TAPService, error) {
 
 	return service.NewTAPServiceBuilder().
 		WithTurboCommunicator(communicator).
-		WithTurboProbe(probe.NewProbeBuilder(registration.TargetType, registration.ProbeCategory).
+		WithTurboProbe(probe.NewProbeBuilder(registration.TargetType(targetAddr), registration.ProbeCategory).
 			WithDiscoveryOptions(probe.FullRediscoveryIntervalSecondsOption(int32(*args.DiscoveryIntervalSec))).
 			RegisteredBy(registrationClient).
 			DiscoversTarget(targetAddr, discoveryClient)).

--- a/prometurbo/pkg/registration/registration_client.go
+++ b/prometurbo/pkg/registration/registration_client.go
@@ -1,15 +1,17 @@
 package registration
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
+	"hash/fnv"
 )
 
 const (
 	TargetIdField string = "targetIdentifier"
 	ProbeCategory string = "Cloud Native"
-	TargetType    string = "Prometheus"
+	targetType    string = "Prometheus"
 	Scope         string = "Scope"
 )
 
@@ -46,4 +48,19 @@ func (p *P8sRegistrationClient) GetAccountDefinition() []*proto.AccountDefEntry 
 		targetIDAcctDefEntry,
 		scopeAcctDefEntry,
 	}
+}
+
+// Return the target type as the default target type appended with hash number from target Id
+func TargetType(targetId string) string {
+	return appendRandomName(targetType, targetId)
+}
+
+func appendRandomName(name, append string) string {
+	return name + "-" + fmt.Sprint(hash(append))
+}
+
+func hash(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
 }


### PR DESCRIPTION
Append a hash number from target name to target type to support adding multiple prometurbo targets.