### PR TITLE
Remove capacity patching in proxy entities

### DIFF
--- a/prometurbo/pkg/discovery/constant/constants.go
+++ b/prometurbo/pkg/discovery/constant/constants.go
@@ -5,20 +5,8 @@ import (
 )
 
 const (
-	// EntityType
-	ApplicationType = int32(1)
-
-	// CommodityType
-	TPS     = "tps"
-	Latency = "latency"
-
 	// MetricType
-	Used     = "used"
-	Capacity = "capacity"
-
-	// Capacity
-	TPSCap     = 20.0
-	LatencyCap = 500.0 //millisec
+	Used = "used"
 
 	// The default namespace of entity property
 	DefaultPropertyNamespace = "DEFAULT"
@@ -36,9 +24,4 @@ var EntityTypeMap = map[proto.EntityDTO_EntityType]struct{}{
 var CommodityTypeMap = map[proto.CommodityDTO_CommodityType]struct{}{
 	proto.CommodityDTO_TRANSACTION:   {},
 	proto.CommodityDTO_RESPONSE_TIME: {},
-}
-
-var CommodityCapMap = map[proto.CommodityDTO_CommodityType]float64{
-	proto.CommodityDTO_TRANSACTION:   TPSCap,
-	proto.CommodityDTO_RESPONSE_TIME: LatencyCap,
 }

--- a/prometurbo/pkg/discovery/discovery_client_test.go
+++ b/prometurbo/pkg/discovery/discovery_client_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/turbonomic/prometurbo/prometurbo/pkg/discovery/exporter"
 	"github.com/turbonomic/turbo-go-sdk/pkg/builder"
 	"github.com/turbonomic/turbo-go-sdk/pkg/proto"
-	"math"
 )
 
 var (
@@ -28,15 +27,13 @@ var (
 			Attribute:  &ipAttr,
 			UseTopoExt: &useTopoExt,
 		}).
-		PatchSellingWithProperty(proto.CommodityDTO_TRANSACTION, []string{constant.Used, constant.Capacity}).
-		PatchSellingWithProperty(proto.CommodityDTO_RESPONSE_TIME, []string{constant.Used, constant.Capacity}).
+		PatchSellingWithProperty(proto.CommodityDTO_TRANSACTION, []string{constant.Used}).
+		PatchSellingWithProperty(proto.CommodityDTO_RESPONSE_TIME, []string{constant.Used}).
 		Build()
 
 	metrics = []*exporter.EntityMetric{
 		newMetric("1.2.3.4", 13.4, 66.7, appType),
 		newMetric("5.6.7.8", 0, 0, appType),
-		newMetric("15.16.17.18", constant.TPSCap, constant.LatencyCap, appType),
-		newMetric("115.116.117.118", constant.TPSCap+10, constant.LatencyCap+10, appType),
 	}
 )
 
@@ -175,16 +172,14 @@ func checkAppResult(metric *exporter.EntityMetric, entity *proto.EntityDTO) erro
 }
 
 func newTrasactionCommodity(used float64, key string) *proto.CommodityDTO {
-	capacity := math.Max(used, constant.TPSCap)
 	comm, _ := builder.NewCommodityDTOBuilder(proto.CommodityDTO_TRANSACTION).
-		Used(used).Capacity(capacity).Key(key).Create()
+		Used(used).Key(key).Create()
 	return comm
 }
 
 func newResponseTimeCommodity(used float64, key string) *proto.CommodityDTO {
-	capacity := math.Max(used, constant.LatencyCap)
 	comm, _ := builder.NewCommodityDTOBuilder(proto.CommodityDTO_RESPONSE_TIME).
-		Used(used).Capacity(capacity).Key(key).Create()
+		Used(used).Key(key).Create()
 	return comm
 }
 

--- a/prometurbo/pkg/discovery/dtofactory/entity_builder.go
+++ b/prometurbo/pkg/discovery/dtofactory/entity_builder.go
@@ -71,7 +71,7 @@ func getReplacementMetaData(entityType proto.EntityDTO_EntityType, commTypes []p
 		if bought {
 			b.PatchBuyingWithProperty(commType, []string{constant.Used})
 		} else {
-			b.PatchSellingWithProperty(commType, []string{constant.Used, constant.Capacity})
+			b.PatchSellingWithProperty(commType, []string{constant.Used})
 		}
 	}
 
@@ -160,20 +160,8 @@ func (b *entityBuilder) createEntityDto() (*proto.EntityDTO, error) {
 			continue
 		}
 
-		capacity, ok := constant.CommodityCapMap[commType]
-		if !ok {
-			err := fmt.Errorf("Missing commodity capacity for type %s", commType)
-			glog.Errorf(err.Error())
-			continue
-		}
-
-		// Adjust the capacity in case utilization > 1 as Market doesn't allow it
-		if value >= capacity {
-			capacity = value
-		}
-
 		commodity, err := builder.NewCommodityDTOBuilder(commType).
-			Used(value).Capacity(capacity).Key(ip).Create()
+			Used(value).Key(ip).Create()
 
 		if err != nil {
 			glog.Errorf("Error building a commodity: %s", err)


### PR DESCRIPTION
Remove capacity patching in proxy entities since prometurbo doesn't have information about capacities for transaction and response time.