### PR TITLE
OM-46220 Change key for vapp and app entities using the service id

### DIFF
--- a/appmetric/pkg/addon/istio_metric.go
+++ b/appmetric/pkg/addon/istio_metric.go
@@ -323,30 +323,27 @@ func (d *istioMetricData) Parse(m *xfire.RawMetric) error {
 	//NOTO: set uuid to its IP if available
 	d.uuid = ip
 
-	//3. pod/svc Name
-	v, ok = labels["destination_svc"]
-	if !ok {
-		err := fmt.Errorf("No content for destination service: %v+", m.Labels)
-		return err
-	}
-	svc, err := d.parseService(v)
-	if err != nil {
-		glog.Errorf("Failed to parse service(%v): %v", v, err)
-		return err
-	}
-	d.Labels[inter.Service] = svc
+	////3. pod/svc Name
+	//v, ok = labels["destination_svc"]
+	//if !ok {
+	//	err := fmt.Errorf("No content for destination service: %v+", m.Labels)
+	//	return err
+	//}
+	//svc, err := d.parseService(v)
+	//if err != nil {
+	//	glog.Errorf("Failed to parse service(%v): %v", v, err)
+	//	return err
+	//}
+	//d.Labels[inter.Service] = svc
 
-	//4. pod/svc Name
+	//3. pod service Name and Namespace
 	v, ok = labels["destination_svc_ns"]
 	if !ok {
 		err := fmt.Errorf("No content for destination service namespace: %v+", m.Labels)
 		return err
 	}
-	svc_ns, err := d.parseService(v)
-	if err != nil {
-		glog.Errorf("Failed to parse service(%v): %v", v, err)
-		return err
-	}
+
+	svc_ns := strings.TrimSpace(v)
 	d.Labels[inter.ServiceNamespace] = svc_ns
 
 	v, ok = labels["destination_svc_name"]
@@ -354,11 +351,8 @@ func (d *istioMetricData) Parse(m *xfire.RawMetric) error {
 		err := fmt.Errorf("No content for destination service name: %v+", m.Labels)
 		return err
 	}
-	svc_name, err := d.parseService(v)
-	if err != nil {
-		glog.Errorf("Failed to parse service(%v): %v", v, err)
-		return err
-	}
+
+	svc_name := strings.TrimSpace(v)
 	d.Labels[inter.ServiceName] = svc_name
 
 	return nil

--- a/appmetric/pkg/addon/istio_metric.go
+++ b/appmetric/pkg/addon/istio_metric.go
@@ -323,19 +323,6 @@ func (d *istioMetricData) Parse(m *xfire.RawMetric) error {
 	//NOTO: set uuid to its IP if available
 	d.uuid = ip
 
-	////3. pod/svc Name
-	//v, ok = labels["destination_svc"]
-	//if !ok {
-	//	err := fmt.Errorf("No content for destination service: %v+", m.Labels)
-	//	return err
-	//}
-	//svc, err := d.parseService(v)
-	//if err != nil {
-	//	glog.Errorf("Failed to parse service(%v): %v", v, err)
-	//	return err
-	//}
-	//d.Labels[inter.Service] = svc
-
 	//3. pod service Name and Namespace
 	v, ok = labels["destination_svc_ns"]
 	if !ok {

--- a/appmetric/pkg/inter/constants.go
+++ b/appmetric/pkg/inter/constants.go
@@ -6,10 +6,13 @@ import (
 
 //Labels
 const (
-	IP       = "ip"
-	Port     = "port"
-	Name     = "name"
-	Category = "category"
+	IP               = "ip"
+	Port             = "port"
+	Name             = "name"
+	Category         = "category"
+	Service          = "service"
+	ServiceNamespace = "service_ns"
+	ServiceName      = "service_name"
 
 	AppEntity  = proto.EntityDTO_APPLICATION
 	VAppEntity = proto.EntityDTO_VIRTUAL_APPLICATION

--- a/appmetric/scripts/istio/ip.turbo.metric.yaml
+++ b/appmetric/scripts/istio/ip.turbo.metric.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   value: response.duration | "0ms"
   dimensions:
+    destination_svc: destination.service | "unknown"
+    destination_svc_name: destination.service.name | "unknown"
+    destination_svc_ns: destination.service.namespace | "unknown"
     destination_uid: destination.uid | "unknown"
     destination_ip: destination.ip | ip("0.0.0.0")
     response_code: response.code | 200
@@ -33,6 +36,9 @@ spec:
   value: "1"
   dimensions:
     destination_uid: destination.uid | "unknown"
+    destination_svc: destination.service | "unknown"
+    destination_svc_name: destination.service.name | "unknown"
+    destination_svc_ns: destination.service.namespace | "unknown"
     response_code: response.code | 200
     destination_ip: destination.ip | ip("0.0.0.0")
   monitored_resource_type: '"UNSPECIFIED"'
@@ -72,6 +78,9 @@ spec:
     label_names:
     - destination_uid
     - destination_ip
+    - destination_svc
+    - destination_svc_name
+    - destination_svc_ns
     - response_code
     buckets:
       explicit_buckets:
@@ -88,6 +97,9 @@ spec:
     label_names:
     - destination_uid
     - destination_ip
+    - destination_svc
+    - destination_svc_name
+    - destination_svc_ns
     - response_code
 ---
 # Rule to send metric instances to a Prometheus handler

--- a/appmetric/scripts/istio/ip.turbo.metric.yaml
+++ b/appmetric/scripts/istio/ip.turbo.metric.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   value: response.duration | "0ms"
   dimensions:
-    destination_svc: destination.service | "unknown"
     destination_svc_name: destination.service.name | "unknown"
     destination_svc_ns: destination.service.namespace | "unknown"
     destination_uid: destination.uid | "unknown"
@@ -36,7 +35,6 @@ spec:
   value: "1"
   dimensions:
     destination_uid: destination.uid | "unknown"
-    destination_svc: destination.service | "unknown"
     destination_svc_name: destination.service.name | "unknown"
     destination_svc_ns: destination.service.namespace | "unknown"
     response_code: response.code | 200
@@ -78,7 +76,6 @@ spec:
     label_names:
     - destination_uid
     - destination_ip
-    - destination_svc
     - destination_svc_name
     - destination_svc_ns
     - response_code
@@ -97,7 +94,6 @@ spec:
     label_names:
     - destination_uid
     - destination_ip
-    - destination_svc
     - destination_svc_name
     - destination_svc_ns
     - response_code

--- a/prometurbo/pkg/discovery/dtofactory/entity_builder.go
+++ b/prometurbo/pkg/discovery/dtofactory/entity_builder.go
@@ -141,13 +141,13 @@ func (b *entityBuilder) createEntityDto() (*proto.EntityDTO, error) {
 	labels := metric.Labels
 
 	var commKey, serviceName, serviceNamespace string
-	for key, val := range labels {
-		if key == "service_name" {
-			serviceName = val
-		}
-		if key == "service_ns" {
-			serviceNamespace = val
-		}
+	serviceName, serviceNameExists := labels["service_name"]
+	serviceNamespace, serviceNamespaceExists := labels["service_ns"]
+
+	if serviceNameExists && serviceNamespaceExists {
+		commKey = fmt.Sprintf("%s/%s", serviceNamespace, serviceName)
+	} else {
+		commKey = ip
 	}
 
 	if serviceNamespace != "" && serviceName != "" {

--- a/prometurbo/pkg/discovery/dtofactory/entity_builder.go
+++ b/prometurbo/pkg/discovery/dtofactory/entity_builder.go
@@ -138,6 +138,23 @@ func (b *entityBuilder) createEntityDto() (*proto.EntityDTO, error) {
 	}
 
 	ip := metric.UID
+	labels := metric.Labels
+
+	var commKey, serviceName, serviceNamespace string
+	for key, val := range labels {
+		if key == "service_name" {
+			serviceName = val
+		}
+		if key == "service_ns" {
+			serviceNamespace = val
+		}
+	}
+
+	if serviceNamespace != "" && serviceName != "" {
+		commKey = fmt.Sprintf("%s/%s", serviceNamespace, serviceName)
+	} else {
+		commKey = ip
+	}
 
 	commodities := []*proto.CommodityDTO{}
 	commTypes := []proto.CommodityDTO_CommodityType{}
@@ -161,7 +178,7 @@ func (b *entityBuilder) createEntityDto() (*proto.EntityDTO, error) {
 		}
 
 		commodity, err := builder.NewCommodityDTOBuilder(commType).
-			Used(value).Key(ip).Create()
+			Used(value).Key(commKey).Create()
 
 		if err != nil {
 			glog.Errorf("Error building a commodity: %s", err)
@@ -189,5 +206,6 @@ func (b *entityBuilder) createEntityDto() (*proto.EntityDTO, error) {
 
 	entityDto.KeepStandalone = &keepStandalone
 
+	glog.V(4).Infof("Entity DTO: %++v", entityDto)
 	return entityDto, nil
 }


### PR DESCRIPTION
- Change the istio-metric.yml to fetch the service namespace and name labels when executing the prometheus query for pod metrics.
- istio-metric parser will extract the lables
- entity dto builder uses the labels to contract the key for virtual application and application entities.