### PR TITLE
Allow creating businessApp when the relabel of business app is used at prometheus

### DIFF
--- a/prometurbo/pkg/discovery/constant/constants.go
+++ b/prometurbo/pkg/discovery/constant/constants.go
@@ -21,6 +21,7 @@ const (
 	SUPPLY_CHAIN_CONSTANT_VIRTUAL_MACHINE_DATA = "virtual_machine_data"
 
 	VAppPrefix = "vApp-"
+	BizAppPrefix = "businessApp-"
 )
 
 var EntityTypeMap = map[proto.EntityDTO_EntityType]struct{}{


### PR DESCRIPTION
This patch only includes the part at the probe side if the business app is populated from appMetric.