### PR TITLE
Support appmetric configuration through configmap

### DIFF
--- a/appmetric/Makefile
+++ b/appmetric/Makefile
@@ -18,7 +18,7 @@ debug: clean
 	go build -gcflags "-N -l" -o ${OUTPUT_DIR}/${bin}.debug ./cmd
 
 docker: clean
-	docker build -t turbonomic/appmetric:6.4dev --build-arg GIT_COMMIT=$(shell git rev-parse --short HEAD) .
+	docker build -t turbonomic/appmetric --build-arg GIT_COMMIT=$(shell git rev-parse --short HEAD) .
 
 test: clean
 	@go test -v -race ./pkg/...

--- a/appmetric/cmd/main.go
+++ b/appmetric/cmd/main.go
@@ -15,6 +15,7 @@ import (
 const (
 	defaultPort           = 8081
 	defaultSampleDuration = "3m"
+	defaultConfigPath     = "/etc/appmetric/appmetric.config"
 )
 
 var (
@@ -25,7 +26,7 @@ var (
 
 func parseFlags() {
 	flag.IntVar(&port, "port", defaultPort, "port to expose metrics (default 8081)")
-	flag.StringVar(&configFileName, "config", "", "path to the metrics discovery config file")
+	flag.StringVar(&configFileName, "config", defaultConfigPath, "path to the metrics discovery config file")
 	flag.StringVar(&sampleDuration, "sampleDuration", defaultSampleDuration, "the sample duration for prometheus query")
 	flag.Parse()
 }

--- a/deploy/prometurbo_yamls/appmetric-config.yaml
+++ b/deploy/prometurbo_yamls/appmetric-config.yaml
@@ -1,0 +1,174 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: appmetric-config
+data:
+  appmetric.config: |-
+    exporters:
+      - name: istio
+        entities:
+          - type: APPLICATION
+            metrics:
+              RESPONSE_TIME:
+                queries:
+                  used: '1000.0*rate(istio_turbo_pod_latency_time_ms_sum{response_code="200"}[3m])/rate(istio_turbo_pod_latency_time_ms_count{response_code="200"}[3m]) >= 0'
+              TRANSACTION:
+                queries:
+                  used: 'rate(istio_turbo_pod_request_count{response_code="200"}[3m]) > 0'
+            attributes:
+              ip:
+                label: destination_ip
+                isIdentifier: true
+              name:
+                label: destination_uid
+                # Convert from "kubernetes://<podName>.<namespace>" to "<namespace>/<podName>"
+                matches: ^kubernetes://(?P<podName>[a-z0-9]([-a-z0-9]*[a-z0-9])?).(?P<namespace>[a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                as: "$namespace/$podName"
+              service_ns:
+                label: destination_svc_ns
+              service_name:
+                label: destination_svc_name
+              target:
+                label: job
+      - name: redis
+        entities:
+          - type: APPLICATION
+            metrics:
+              TRANSACTION:
+                queries:
+                  used: 'rate(redis_commands_processed_total[3m])'
+            attributes:
+              ip:
+                label: addr
+                # Convert from "ip:host" to "ip"
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              target:
+                label: job
+      - name: cassandra
+        entities:
+          - type: APPLICATION_COMPONENT
+            metrics:
+              RESPONSE_TIME:
+                queries:
+                  used: '0.001*max(cassandra_stats{name=~"org:apache:cassandra:metrics:table:(write|read)latency:99thpercentile"}) by (instance)'
+              TRANSACTION:
+                queries:
+                  used: 'sum(cassandra_stats{name=~"org:apache:cassandra:metrics:table:(write|read)latency:oneminuterate"}) by (instance)'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              target:
+                label: job
+      - name: webdriver
+        entities:
+          - type: APPLICATION_COMPONENT
+            hostedOnVM: true
+            metrics:
+              RESPONSE_TIME:
+                queries:
+                  used: '1000*(navigation_timing_load_event_end_seconds{job="webdriver"}-navigation_timing_start_seconds{job="webdriver"})'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              target:
+                label: job
+      - name: mysql
+        entities:
+          - type: DATABASE_SERVER
+            hostedOnVM: true
+            metrics:
+              DB_MEM:
+                queries:
+                  used: 'mysql_global_status_innodb_buffer_pool_bytes_data/1024'
+                  capacity: 'mysql_global_variables_innodb_buffer_pool_size/1024'
+              DB_CACHE_HIT_RATE:
+                queries:
+                  used: '1/(1 + delta(mysql_global_status_innodb_buffer_pool_reads[10m])/delta(mysql_global_status_innodb_buffer_pool_read_requests[10m]))*100'
+              CONNECTION:
+                queries:
+                  used: 'mysql_global_status_threads_connected{job="mysql"}'
+                  capacity: 'mysql_global_variables_max_connections{job="mysql"}'
+              TRANSACTION:
+                queries:
+                  used: 'sum(rate(mysql_global_status_commands_total{command=~"(commit|rollback)"}[5m])) without (command)'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              business_app:
+                label: job
+      - name: node
+        entities:
+          - type: VIRTUAL_MACHINE
+            metrics:
+              VCPU:
+                queries:
+                  used: 'sum by (instance, job) (irate(node_cpu_seconds_total{}[3m]))'
+              VMEM:
+                queries:
+                  used: 'node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{}'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              target:
+                label: job
+      - name: jmx-xl
+        entities:
+          - type: APPLICATION_COMPONENT
+            metrics:
+              # TODO: Some of the XL services may be more relevant on kafka messages vs grpc
+              TRANSACTION:
+                queries:
+                  used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[5m]) or delta(api_call_counts{job="xl",failed="false"}[5m]))/300'
+              RESPONSE_TIME:
+                queries:
+                  used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0 or (delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+              THREADS:
+                queries:
+                  used: 'jvm_threads_current{job="xl"}'
+                  capacity: 'jvm_threads_peak{job="xl"}'
+              COLLECTION_TIME:
+                queries:
+                  used: '(sum without(gc)(jvm_gc_collection_seconds_sum{job="xl"}))/(component_jvm_uptime_minutes*60)*100'
+              HEAP:
+                queries:
+                  used: 'jvm_memory_bytes_used{area="heap",job="xl"}/1024'
+                  capacity: 'jvm_memory_bytes_max{area="heap",job="xl"}/1024'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              business_app:
+                label: job
+      - name: jmx
+        entities:
+          - type: APPLICATION_COMPONENT
+            metrics:
+              VCPU:
+                queries:
+                  used: 'java_lang_OperatingSystem_ProcessCpuLoad'
+              VMEM:
+                queries:
+                  used: 'java_lang_Memory_HeapMemoryUsage_used'
+              COLLECTION_TIME:
+                queries:
+                  used: 'java_lang_GarbageCollector_CollectionTime'
+              RESPONSE_TIME:
+                queries:
+                  used: 'rate(Catalina_GlobalRequestProcessor_processingTime{name=~".*http-.*"}[3m])'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              target:
+                label: job

--- a/deploy/prometurbo_yamls/prometurbo.yaml
+++ b/deploy/prometurbo_yamls/prometurbo.yaml
@@ -1,12 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometurbo
-  namespace: turbo
   labels:
     app: prometurbo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometurbo
   template:
     metadata:
       labels:
@@ -15,7 +17,7 @@ spec:
       serviceAccount: turbo-user
       containers:
         - name: prometurbo
-          image: turbonomic/prometurbo:6.4dev
+          image: turbonomic/prometurbo
           imagePullPolicy: IfNotPresent
           args:
             - --v=2
@@ -25,17 +27,24 @@ spec:
             readOnly: true
           - name: varlog
             mountPath: /var/log
-        - image: turbonomic/appmetric:6.4dev
+        - image: turbonomic/appmetric
           imagePullPolicy: IfNotPresent
           name: appmetric
           args:
           - --v=2
           ports:
           - containerPort: 8081
+          volumeMounts:
+            - name: appmetric-config
+              mountPath: /etc/appmetric
+              readOnly: true
       volumes:
       - name: prometurbo-config
         configMap: 
           name: prometurbo-config
+      - name: appmetric-config
+        configMap:
+          name: appmetric-config
       - name: varlog
         emptyDir: {}
       restartPolicy: Always

--- a/prometurbo/Makefile
+++ b/prometurbo/Makefile
@@ -18,7 +18,7 @@ debug: clean
 	go build -gcflags "-N -l" -o ${OUTPUT_DIR}/${bin}.debug ./cmd
 
 docker: clean
-	docker build -t turbonomic/prometurbo:6.4dev --build-arg GIT_COMMIT=$(shell git rev-parse --short HEAD) .
+	docker build -t turbonomic/prometurbo --build-arg GIT_COMMIT=$(shell git rev-parse --short HEAD) .
 
 test: clean
 	@go test -v -race ./pkg/...


### PR DESCRIPTION
The PR:

* Supports reading the `appmetric` configuration from `configMap`
* Fixes a few issues in the deployment yaml
* Remove the `6.4dev` label in `Makefile`

I will submit a separate PR for the changes in helm charts, and also adding the operator.