### PR TITLE
prometurbo configurable prometheus url for appmetric

### DIFF
--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
           image: {{ .Values.image.apprepository }}:{{ .Values.image.apptag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - --promUrl={{ .Values.prometurboTargetConfig.targetAddress }}
             - --v={{ .Values.args.logginglevel }}
           ports:
           - containerPort: 8081

--- a/deploy/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
           image: {{ .Values.image.apprepository }}:{{ .Values.image.apptag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - --promUrl={{ .Values.prometurboTargetConfig.targetAddress }}
             - --v={{ .Values.args.logginglevel }}
           ports:
           - containerPort: 8081

--- a/deploy/prometurbo_yamls/prometurbo.yaml
+++ b/deploy/prometurbo_yamls/prometurbo.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometurbo
@@ -28,7 +28,8 @@ spec:
           imagePullPolicy: IfNotPresent
           name: appmetric
           args:
-          - --v=2
+            - --promUrl=http://prometheus.istio-system:9090
+            - --v=2
           ports:
           - containerPort: 8081
       volumes:


### PR DESCRIPTION
 helm install prometurbo prometurbo --namespace test --dry-run --debug
---
# Source: prometurbo/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: prometurbo
  labels:
    app.kubernetes.io/name: prometurbo
    helm.sh/chart: prometurbo-0.1.0
    app.kubernetes.io/instance: prometurbo
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: prometurbo
      app.kubernetes.io/instance: prometurbo
  template:
    metadata:
      labels:
        app.kubernetes.io/name: prometurbo
        app.kubernetes.io/instance: prometurbo
    spec:
      containers:
        - name: prometurbo
          image: turbonomic/prometurbo:7.21.0
          imagePullPolicy: IfNotPresent
          args:
            - --keepStandalone=false
            - --createProxyVM=false
            - --v=2
          volumeMounts:
          - name: prometurbo-config
            mountPath: /etc/prometurbo
            readOnly: true
          - name: turbonomic-credentials-volume
            mountPath: /etc/turbonomic-credentials
            readOnly: true
          - name: varlog
            mountPath: /var/log
        - name: appmetric
          image: turbonomic/appmetric:7.21.0
          imagePullPolicy: IfNotPresent
          args:
            - --promUrl=http://prometheus.istio-system:9090
            - --v=2
          ports:
          - containerPort: 8081
...