### PR TITLE
Add key to commodities in Applications and Services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/prometheus/common v0.9.1
-	github.com/turbonomic/turbo-go-sdk v0.0.0-20200505151021-7fa24b134b17
+	github.com/turbonomic/turbo-go-sdk v0.0.0-20200507163116-7a61dabb1b3e
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/turbonomic/turbo-api v0.0.0-20200413140231-3bef8fb11708/go.mod h1:L3eNZzTD3Iw8GV+cfeJD/lfDaEGPbZZGQrtml71yG10=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20200505151021-7fa24b134b17 h1:X6BvOzMH8wjAlp1faBpx1fywL2HZY0auN4BAyOw/DvM=
-github.com/turbonomic/turbo-go-sdk v0.0.0-20200505151021-7fa24b134b17/go.mod h1:80tK3rQ6cafsQglfkF7KYElmiveLMrjR9IavC2vMopk=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20200507163116-7a61dabb1b3e h1:LbXUGhlXiALiK1PlWL0/E8J41S+1ue2NmfPcdUGXJnM=
+github.com/turbonomic/turbo-go-sdk v0.0.0-20200507163116-7a61dabb1b3e/go.mod h1:80tK3rQ6cafsQglfkF7KYElmiveLMrjR9IavC2vMopk=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/config/prometheus-config.yaml
+++ b/pkg/config/prometheus-config.yaml
@@ -186,6 +186,10 @@ exporters:
             isIdentifier: true
           service:
             label: service
+          service_ns:
+            label: namespace
+          service_name:
+            label: service
       - type: databaseServer
         hostedOnVM: true
         metrics:

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data/dif_metric.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data/dif_metric.go
@@ -28,17 +28,17 @@ const (
 	PCT   DIFMetricUnit = "pct"
 )
 
-type DIFMetricValKey string
+type DIFMetricValKind string
 
 const (
-	KEY         DIFMetricValKey = "key"
-	DESCRIPTION DIFMetricValKey = "description"
-	RAWDATA     DIFMetricValKey = "rawData"
-	AVERAGE     DIFMetricValKey = "average"
-	MAX         DIFMetricValKey = "max"
-	MIN         DIFMetricValKey = "min"
-	CAPACITY    DIFMetricValKey = "capacity"
-	UNIT        DIFMetricValKey = "unit"
+	KEY         DIFMetricValKind = "key"
+	DESCRIPTION DIFMetricValKind = "description"
+	RAWDATA     DIFMetricValKind = "rawData"
+	AVERAGE     DIFMetricValKind = "average"
+	MAX         DIFMetricValKind = "max"
+	MIN         DIFMetricValKind = "min"
+	CAPACITY    DIFMetricValKind = "capacity"
+	UNIT        DIFMetricValKind = "unit"
 )
 
 const (

--- a/vendor/github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data/dif_types.go
+++ b/vendor/github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data/dif_types.go
@@ -105,7 +105,7 @@ func (e *DIFEntity) Matching(id string) *DIFEntity {
 	return e
 }
 
-func (e *DIFEntity) AddMetric(metricType string, key DIFMetricValKey, value float64) {
+func (e *DIFEntity) AddMetric(metricType string, kind DIFMetricValKind, value float64, key string) {
 	meList, found := e.Metrics[metricType]
 	if !found {
 		meList = append(meList, &DIFMetricVal{})
@@ -114,10 +114,13 @@ func (e *DIFEntity) AddMetric(metricType string, key DIFMetricValKey, value floa
 	if len(meList) < 1 {
 		return
 	}
-	if key == AVERAGE {
+	if kind == AVERAGE {
 		meList[0].Average = &value
-	} else if key == CAPACITY {
+	} else if kind == CAPACITY {
 		meList[0].Capacity = &value
+	}
+	if key != "" {
+		meList[0].Key = &key
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/golang/glog
 github.com/golang/protobuf/proto
 # github.com/prometheus/common v0.9.1
 github.com/prometheus/common/model
-# github.com/turbonomic/turbo-go-sdk v0.0.0-20200505151021-7fa24b134b17
+# github.com/turbonomic/turbo-go-sdk v0.0.0-20200507163116-7a61dabb1b3e
 github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data
 github.com/turbonomic/turbo-go-sdk/pkg/proto
 # gopkg.in/yaml.v2 v2.2.8


### PR DESCRIPTION
This PR allows `prometurbo` to add key to application metrics. These keys are in the form of `namespace/service_name`. After stitching with applications and services from `kubeturbo`, theses applications and services will be participating in the same market for horizontal scale analysis.

![image](https://user-images.githubusercontent.com/10012486/81322332-cf28b380-9061-11ea-9751-04ae2621b663.png)
