### PR TITLE
Add istio 1.5 exporter configuration

### DIFF
--- a/deploy/prometurbo-operator/deploy/operator.yaml
+++ b/deploy/prometurbo-operator/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: prometurbo-operator
           # Replace this with the built image name
-          image: turbonomic/prometurbo-operator:7.21
+          image: turbonomic/prometurbo-operator:7.22
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
@@ -17,6 +17,33 @@ data:
             metrics:
               - type: responseTime
                 queries:
+                  used: 'rate(istio_request_duration_milliseconds_sum{request_protocol="http",response_code="200",reporter="destination"}[3m])/rate(istio_request_duration_milliseconds_count{}[3m]) >= 0'
+              - type: transaction
+                queries:
+                  used: 'rate(istio_requests_total{request_protocol="http",response_code="200",reporter="destination"}[3m]) > 0'
+              - type: responseTime
+                queries:
+                  used: 'rate(istio_request_duration_milliseconds_sum{request_protocol="grpc",grpc_response_status="0",response_code="200",reporter="destination"}[3m])/rate(istio_request_duration_milliseconds_count{}[3m]) >= 0'
+              - type: transaction
+                queries:
+                  used: 'rate(istio_requests_total{request_protocol="grpc",grpc_response_status="0",response_code="200",reporter="destination"}[3m]) > 0'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              service_ns:
+                label: destination_service_namespace
+              service_name:
+                label: destination_service_name
+              service:
+                label: destination_service
+      istio-1.4:
+        entities:
+          - type: application
+            metrics:
+              - type: responseTime
+                queries:
                   used: '1000.0*rate(istio_turbo_pod_latency_time_ms_sum{response_code="200"}[3m])/rate(istio_turbo_pod_latency_time_ms_count{response_code="200"}[3m]) >= 0'
               - type: transaction
                 queries:
@@ -208,6 +235,10 @@ data:
                 matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
                 isIdentifier: true
               service:
+                label: service
+              service_ns:
+                label: namespace
+              service_name:
                 label: service
 {{- if .Values.extraPrometheusExporters }}
 {{ tpl .Values.extraPrometheusExporters . | indent 6 }}

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
@@ -17,16 +17,16 @@ data:
             metrics:
               - type: responseTime
                 queries:
-                  used: 'rate(istio_request_duration_milliseconds_sum{request_protocol="http",response_code="200",reporter="destination"}[3m])/rate(istio_request_duration_milliseconds_count{}[3m]) >= 0'
+                  used: 'rate(istio_request_duration_milliseconds_sum{request_protocol="http",response_code="200",reporter="destination"}[1m])/rate(istio_request_duration_milliseconds_count{}[1m]) >= 0'
               - type: transaction
                 queries:
-                  used: 'rate(istio_requests_total{request_protocol="http",response_code="200",reporter="destination"}[3m]) > 0'
+                  used: 'rate(istio_requests_total{request_protocol="http",response_code="200",reporter="destination"}[1m]) > 0'
               - type: responseTime
                 queries:
-                  used: 'rate(istio_request_duration_milliseconds_sum{request_protocol="grpc",grpc_response_status="0",response_code="200",reporter="destination"}[3m])/rate(istio_request_duration_milliseconds_count{}[3m]) >= 0'
+                  used: 'rate(istio_request_duration_milliseconds_sum{request_protocol="grpc",grpc_response_status="0",response_code="200",reporter="destination"}[1m])/rate(istio_request_duration_milliseconds_count{}[1m]) >= 0'
               - type: transaction
                 queries:
-                  used: 'rate(istio_requests_total{request_protocol="grpc",grpc_response_status="0",response_code="200",reporter="destination"}[3m]) > 0'
+                  used: 'rate(istio_requests_total{request_protocol="grpc",grpc_response_status="0",response_code="200",reporter="destination"}[1m]) > 0'
             attributes:
               ip:
                 label: instance

--- a/deploy/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo/templates/configmap-prometurbo.yaml
@@ -17,6 +17,27 @@ data:
             metrics:
               - type: responseTime
                 queries:
+                  used: 'rate(istio_request_duration_milliseconds_sum{response_code="200",reporter="destination"}[3m])/rate(istio_request_duration_milliseconds_count{response_code="200",reporter="destination"}[3m]) >= 0'
+              - type: transaction
+                queries:
+                  used: 'rate(istio_requests_total{response_code="200",reporter="destination"}[3m]) > 0'
+            attributes:
+              ip:
+                label: instance
+                matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+                isIdentifier: true
+              service_ns:
+                label: destination_service_namespace
+              service_name:
+                label: destination_service_name
+              service:
+                label: destination_service
+      istio-1.4:
+        entities:
+          - type: application
+            metrics:
+              - type: responseTime
+                queries:
                   used: '1000.0*rate(istio_turbo_pod_latency_time_ms_sum{response_code="200"}[3m])/rate(istio_turbo_pod_latency_time_ms_count{response_code="200"}[3m]) >= 0'
               - type: transaction
                 queries:
@@ -184,6 +205,10 @@ data:
                 matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
                 isIdentifier: true
               service:
+                label: service
+              service_ns:
+                label: namespace
+              service_name:
                 label: service
           - type: databaseServer
             hostedOnVM: true

--- a/pkg/config/prometheus-config.yaml
+++ b/pkg/config/prometheus-config.yaml
@@ -18,6 +18,27 @@ exporters:
         metrics:
           - type: responseTime
             queries:
+              used: 'rate(istio_request_duration_milliseconds_sum{response_code="200",reporter="destination"}[3m])/rate(istio_request_duration_milliseconds_count{response_code="200",reporter="destination"}[3m]) >= 0'
+          - type: transaction
+            queries:
+              used: 'rate(istio_requests_total{response_code="200",reporter="destination"}[3m]) > 0'
+        attributes:
+          ip:
+            label: instance
+            matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
+            isIdentifier: true
+          service_ns:
+            label: destination_service_namespace
+          service_name:
+            label: destination_service_name
+          service:
+            label: destination_service
+  istio-1.4:
+    entities:
+      - type: application
+        metrics:
+          - type: responseTime
+            queries:
               used: '1000.0*rate(istio_turbo_pod_latency_time_ms_sum{response_code="200"}[3m])/rate(istio_turbo_pod_latency_time_ms_count{response_code="200"}[3m]) >= 0'
           - type: transaction
             queries:


### PR DESCRIPTION
This PR:

Add istio 1.5 exporter configuration to `prometurbo`.

Istio 1.5 used [Telemetry V2](https://istio.io/docs/reference/config/telemetry/metrics/), and the default standard metrics already meets our requirement, so there is no need for custom metrics any more.