### PR TITLE
Fix miscellaneous issues related to target turbo with turbo

### DIFF
--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
@@ -194,10 +194,6 @@ data:
               - type: responseTime
                 queries:
                   used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0) * 1000'
-              - type: threads
-                queries:
-                  used: 'jvm_threads_current{job="xl"}'
-                  capacity: 'jvm_threads_peak{job="xl"}'
               - type: collectionTime
                 queries:
                   used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
@@ -141,7 +141,7 @@ data:
                   capacity: 'java_lang_Memory_HeapMemoryUsage_max/1024'
               - type: collectionTime
                 queries:
-                  used: 'sum without (name) (java_lang_GarbageCollector_CollectionTime)/java_lang_Runtime_Uptime*100'
+                  used: 'sum without (name) (delta(java_lang_GarbageCollector_CollectionTime)[10m])/600*100'
               - type: responseTime
                 queries:
                   used: 'rate(Catalina_GlobalRequestProcessor_processingTime{name=~".*http-.*"}[3m])'
@@ -200,7 +200,7 @@ data:
                   capacity: 'jvm_threads_peak{job="xl"}'
               - type: collectionTime
                 queries:
-                  used: '(sum without(gc)(jvm_gc_collection_seconds_sum{job="xl"}))/(component_jvm_uptime_minutes*60)*100'
+                  used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'
               - type: heap
                 queries:
                   used: 'jvm_memory_bytes_used{area="heap",job="xl"}/1024'

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
@@ -157,10 +157,10 @@ data:
             metrics:
               - type: transaction
                 queries:
-                  used: 'sum by (instance,job,service,uri) (rate(api_call_latency_in_seconds_count[5m]))'
+                  used: 'sum by (instance,job,service,uri) (rate(api_call_latency_in_seconds_count{job="xl"}[10m]))'
               - type: responseTime
                 queries:
-                  used: 'avg by (instance,job,service,uri) ((delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+                  used: 'avg by (instance,job,service,uri) ((delta(api_call_latency_in_seconds_sum{job="xl"}[10m])/delta(api_call_latency_in_seconds_count[10m])) > 0) * 1000'
             attributes:
               id:
                 label: uri
@@ -183,17 +183,17 @@ data:
               # HTTP metrics
               - type: transaction
                 queries:
-                  used: 'sum by (instance,service) (delta(api_call_counts{job="xl",failed="false"}[5m]))/300'
+                  used: 'sum by (instance,service) (delta(api_call_counts{job="xl",failed="false"}[10m]))/600'
               - type: responseTime
                 queries:
-                  used: 'avg by (instance,service) ((delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+                  used: 'avg by (instance,service) ((delta(api_call_latency_in_seconds_sum{job="xl"}[10m])/delta(api_call_latency_in_seconds_count[10m])) > 0) * 1000'
               # GRPC metrics
               - type: transaction
                 queries:
-                  used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[5m]))/300'
+                  used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[10m]))/600'
               - type: responseTime
                 queries:
-                  used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0) * 1000'
+                  used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum{job="xl"}[10m])/delta(grpc_server_handled_latency_seconds_count[10m])) > 0) * 1000'
               - type: collectionTime
                 queries:
                   used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'
@@ -207,6 +207,10 @@ data:
                 matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
                 isIdentifier: true
               service:
+                label: service
+              service_ns:
+                label: namespace
+              service_name:
                 label: service
           - type: databaseServer
             hostedOnVM: true
@@ -224,17 +228,13 @@ data:
                   capacity: 'mysql_global_variables_max_connections{job="xl"}'
               - type: transaction
                 queries:
-                  used: 'sum(rate(mysql_global_status_commands_total{job="xl",command=~"(commit|rollback)"}[5m])) without (command)'
+                  used: 'sum(rate(mysql_global_status_commands_total{job="xl",command=~"(commit|rollback)"}[10m])) without (command)'
             attributes:
               ip:
                 label: host_ip
                 matches: \d{1,3}(?:\.\d{1,3}){3}(?::\d{1,5})??
                 isIdentifier: true
               service:
-                label: service
-              service_ns:
-                label: namespace
-              service_name:
                 label: service
 {{- if .Values.extraPrometheusExporters }}
 {{ tpl .Values.extraPrometheusExporters . | indent 6 }}

--- a/deploy/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo/templates/configmap-prometurbo.yaml
@@ -188,10 +188,6 @@ data:
               - type: responseTime
                 queries:
                   used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0) * 1000'
-              - type: threads
-                queries:
-                  used: 'jvm_threads_current{job="xl"}'
-                  capacity: 'jvm_threads_peak{job="xl"}'
               - type: collectionTime
                 queries:
                   used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'

--- a/deploy/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo/templates/configmap-prometurbo.yaml
@@ -135,7 +135,7 @@ data:
                   capacity: 'java_lang_Memory_HeapMemoryUsage_max/1024'
               - type: collectionTime
                 queries:
-                  used: 'sum without (name) (java_lang_GarbageCollector_CollectionTime)/java_lang_Runtime_Uptime*100'
+                  used: 'sum without (name) (delta(java_lang_GarbageCollector_CollectionTime)[10m])/600*100'
               - type: responseTime
                 queries:
                   used: 'rate(Catalina_GlobalRequestProcessor_processingTime{name=~".*http-.*"}[3m])'
@@ -194,7 +194,7 @@ data:
                   capacity: 'jvm_threads_peak{job="xl"}'
               - type: collectionTime
                 queries:
-                  used: '(sum without(gc)(jvm_gc_collection_seconds_sum{job="xl"}))/(component_jvm_uptime_minutes*60)*100'
+                  used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'
               - type: heap
                 queries:
                   used: 'jvm_memory_bytes_used{area="heap",job="xl"}/1024'

--- a/deploy/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo/templates/configmap-prometurbo.yaml
@@ -151,10 +151,10 @@ data:
             metrics:
               - type: transaction
                 queries:
-                  used: 'sum by (instance,job,service,uri) (rate(api_call_latency_in_seconds_count[5m]))'
+                  used: 'sum by (instance,job,service,uri) (rate(api_call_latency_in_seconds_count{job="xl"}[10m]))'
               - type: responseTime
                 queries:
-                  used: 'avg by (instance,job,service,uri) ((delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+                  used: 'avg by (instance,job,service,uri) ((delta(api_call_latency_in_seconds_sum{job="xl"}[10m])/delta(api_call_latency_in_seconds_count[10m])) > 0) * 1000'
             attributes:
               id:
                 label: uri
@@ -177,17 +177,17 @@ data:
               # HTTP metrics
               - type: transaction
                 queries:
-                  used: 'sum by (instance,service) (delta(api_call_counts{job="xl",failed="false"}[5m]))/300'
+                  used: 'sum by (instance,service) (delta(api_call_counts{job="xl",failed="false"}[10m]))/600'
               - type: responseTime
                 queries:
-                  used: 'avg by (instance,service) ((delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+                  used: 'avg by (instance,service) ((delta(api_call_latency_in_seconds_sum{job="xl"}[10m])/delta(api_call_latency_in_seconds_count[10m])) > 0) * 1000'
               # GRPC metrics
               - type: transaction
                 queries:
-                  used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[5m]))/300'
+                  used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[10m]))/600'
               - type: responseTime
                 queries:
-                  used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0) * 1000'
+                  used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum{job="xl"}[10m])/delta(grpc_server_handled_latency_seconds_count[10m])) > 0) * 1000'
               - type: collectionTime
                 queries:
                   used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'
@@ -222,7 +222,7 @@ data:
                   capacity: 'mysql_global_variables_max_connections{job="xl"}'
               - type: transaction
                 queries:
-                  used: 'sum(rate(mysql_global_status_commands_total{job="xl",command=~"(commit|rollback)"}[5m])) without (command)'
+                  used: 'sum(rate(mysql_global_status_commands_total{job="xl",command=~"(commit|rollback)"}[10m])) without (command)'
             attributes:
               ip:
                 label: host_ip

--- a/pkg/config/prometheus-config.yaml
+++ b/pkg/config/prometheus-config.yaml
@@ -152,10 +152,10 @@ exporters:
         metrics:
           - type: transaction
             queries:
-              used: 'sum by (instance,job,service,uri) (rate(api_call_latency_in_seconds_count[5m]))'
+              used: 'sum by (instance,job,service,uri) (rate(api_call_latency_in_seconds_count{job="xl"}[10m]))'
           - type: responseTime
             queries:
-              used: 'avg by (instance,job,service,uri) ((delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+              used: 'avg by (instance,job,service,uri) ((delta(api_call_latency_in_seconds_sum{job="xl"}[10m])/delta(api_call_latency_in_seconds_count[10m])) > 0) * 1000'
         attributes:
           id:
             label: uri
@@ -178,17 +178,17 @@ exporters:
           # HTTP metrics
           - type: transaction
             queries:
-              used: 'sum by (instance,service) (delta(api_call_counts{job="xl",failed="false"}[5m]))/300'
+              used: 'sum by (instance,service) (delta(api_call_counts{job="xl",failed="false"}[10m]))/600'
           - type: responseTime
             queries:
-              used: 'avg by (instance,service) ((delta(api_call_latency_in_seconds_sum[15m])/delta(api_call_latency_in_seconds_count[15m])) > 0) * 1000'
+              used: 'avg by (instance,service) ((delta(api_call_latency_in_seconds_sum{job="xl"}[10m])/delta(api_call_latency_in_seconds_count[10m])) > 0) * 1000'
           # GRPC metrics
           - type: transaction
             queries:
-              used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[5m]))/300'
+              used: 'sum by (instance,service) (delta(grpc_server_handled_total{job="xl",code="OK"}[10m]))/600'
           - type: responseTime
             queries:
-              used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0) * 1000'
+              used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum{job="xl"}[10m])/delta(grpc_server_handled_latency_seconds_count[10m])) > 0) * 1000'
           - type: collectionTime
             queries:
               used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'
@@ -223,7 +223,7 @@ exporters:
               capacity: 'mysql_global_variables_max_connections{job="xl"}'
           - type: transaction
             queries:
-              used: 'sum(rate(mysql_global_status_commands_total{job="xl",command=~"(commit|rollback)"}[5m])) without (command)'
+              used: 'sum(rate(mysql_global_status_commands_total{job="xl",command=~"(commit|rollback)"}[10m])) without (command)'
         attributes:
           ip:
             label: host_ip

--- a/pkg/config/prometheus-config.yaml
+++ b/pkg/config/prometheus-config.yaml
@@ -136,7 +136,7 @@ exporters:
               capacity: 'java_lang_Memory_HeapMemoryUsage_max/1024'
           - type: collectionTime
             queries:
-              used: 'sum without (name) (java_lang_GarbageCollector_CollectionTime)/java_lang_Runtime_Uptime*100'
+              used: 'sum without (name) (delta(java_lang_GarbageCollector_CollectionTime)[10m])/600*100'
           - type: responseTime
             queries:
               used: 'rate(Catalina_GlobalRequestProcessor_processingTime{name=~".*http-.*"}[3m])'
@@ -195,7 +195,7 @@ exporters:
               capacity: 'jvm_threads_peak{job="xl"}'
           - type: collectionTime
             queries:
-              used: '(sum without(gc)(jvm_gc_collection_seconds_sum{job="xl"}))/(component_jvm_uptime_minutes*60)*100'
+              used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'
           - type: heap
             queries:
               used: 'jvm_memory_bytes_used{area="heap",job="xl"}/1024'

--- a/pkg/config/prometheus-config.yaml
+++ b/pkg/config/prometheus-config.yaml
@@ -189,10 +189,6 @@ exporters:
           - type: responseTime
             queries:
               used: 'avg by (instance,service) ((delta(grpc_server_handled_latency_seconds_sum[15m])/delta(grpc_server_handled_latency_seconds_count[15m])) > 0) * 1000'
-          - type: threads
-            queries:
-              used: 'jvm_threads_current{job="xl"}'
-              capacity: 'jvm_threads_peak{job="xl"}'
           - type: collectionTime
             queries:
               used: 'sum without(gc) (delta(jvm_gc_collection_seconds_sum{job="xl"}[10m]))/600*100'

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/turbonomic/prometurbo/pkg/config"
@@ -104,7 +105,7 @@ func (t *BusinessTopology) buildBizDIFEntities(svcMap map[string][]*data.DIFEnti
 				bizTransEntity := bizTransToDIFEntity(trans, bizAppId)
 				if bizTransEntityDiscovered, found := transMap[trans.Path]; found {
 					bizTransEntityDiscovered.PartOf = bizTransEntity.PartOf
-					bizEntities = append(bizEntities, bizTransEntityDiscovered)
+					bizEntities = append(bizEntities, bizTransEntityDiscovered.WithName(bizTransEntity.Name))
 				} else {
 					bizEntities = append(bizEntities, bizTransEntity)
 				}
@@ -128,6 +129,9 @@ func bizTransToDIFEntity(bizTrans config.Transaction, bizApp string) *data.DIFEn
 	name := bizTrans.Name
 	if name == "" {
 		name = bizTrans.Path
+	}
+	if !strings.HasPrefix(name, "/") {
+		name = "/" + name
 	}
 	bizTransDIFEntity := data.NewDIFEntity(bizTrans.Path, "businessTransaction").
 		WithName(name).


### PR DESCRIPTION
This PR addresses a few issues related to Target turbo with turbo use case:

* [OM-58801](https://vmturbo.atlassian.net/browse/OM-58801): Use configured display name for business transactions.
![image](https://user-images.githubusercontent.com/10012486/84674211-aaddb380-aef8-11ea-8df6-30a1cbc88ba9.png)
* [OM-59080](https://vmturbo.atlassian.net/browse/OM-59080): Do not send business transactions that are not specified in topology configuration.
![image](https://user-images.githubusercontent.com/10012486/84674264-bcbf5680-aef8-11ea-84f6-854c9ae664c4.png)
* [OM-58843](https://vmturbo.atlassian.net/browse/OM-58843): Set the time range of prometheus query range vector to 10 min to be consistent with the default discovery interval.
* Modify the query for garbage collection time to compute the value as the **percentage** of time spent on garbage collection during the past 10 min.
* Remove the query for JVM THREAD, as it is not the exact metric we are looking for. We want to get the thread count in a threadpool which is not available.
* Prefix a **DatabasServer-** string to the display name of a discovered database server.
![image](https://user-images.githubusercontent.com/10012486/84674454-ed9f8b80-aef8-11ea-9e9a-b1d2b1531c32.png)
