### PR TITLE
Concurrent discovery

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,10 +1,8 @@
 package provider
 
 import (
-	"math"
-
 	"github.com/golang/glog"
-	"github.com/turbonomic/prometurbo/pkg/prometheus"
+	"github.com/turbonomic/prometurbo/pkg/worker"
 	"github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data"
 )
 
@@ -16,6 +14,7 @@ var metricKindToDIFMetricValKind = map[string]data.DIFMetricValKind{
 type MetricProvider struct {
 	serverDefs   map[string]*serverDef
 	exporterDefs map[string]*exporterDef
+	dispatcher   *worker.Dispatcher
 }
 
 func NewProvider(serverDefs map[string]*serverDef, exporterDefs map[string]*exporterDef) *MetricProvider {
@@ -25,100 +24,37 @@ func NewProvider(serverDefs map[string]*serverDef, exporterDefs map[string]*expo
 	}
 }
 
-func (p *MetricProvider) GetEntityMetrics() ([]*data.DIFEntity, error) {
-	var entityMetrics []*data.DIFEntity
+func (p *MetricProvider) WithDispatcher(dispatcher *worker.Dispatcher) *MetricProvider {
+	p.dispatcher = dispatcher
+	return p
+}
 
-	// TODO: use goroutine
+func (p *MetricProvider) Start() {
+	p.dispatcher.Start()
+}
+
+func (p *MetricProvider) GetEntityMetrics() ([]*data.DIFEntity, error) {
+	var tasks []*Task
 	for _, serverDef := range p.serverDefs {
-		var metricsForProms []*data.DIFEntity
 		for _, exporter := range serverDef.exporters {
 			exporterDef, found := p.exporterDefs[exporter]
 			if !found {
 				continue
 			}
-			metricsForExporters := getMetricsForExporter(serverDef.promClient, exporterDef)
-			metricsForProms = append(metricsForProms, metricsForExporters...)
-		}
-		entityMetrics = append(entityMetrics, metricsForProms...)
-	}
-
-	return entityMetrics, nil
-}
-
-func getMetricsForExporter(promClient *prometheus.RestClient, exporterDef *exporterDef) []*data.DIFEntity {
-	var entityMetricsForExporter []*data.DIFEntity
-	for _, entityDef := range exporterDef.entityDefs {
-		metricsForEntity := getMetricsForEntity(promClient, entityDef)
-		entityMetricsForExporter = append(entityMetricsForExporter, metricsForEntity...)
-	}
-	return entityMetricsForExporter
-}
-
-func getMetricsForEntity(promClient *prometheus.RestClient, entityDef *entityDef) []*data.DIFEntity {
-	var entityMetrics []*data.DIFEntity
-	var entityMetricsMap = map[string]*data.DIFEntity{}
-	for _, metricDef := range entityDef.metricDefs {
-		entityType := entityDef.eType
-		for metricKind, metricQuery := range metricDef.queries {
-			metricType := metricDef.mType
-			metricSeries, err := promClient.GetMetrics(metricQuery)
-			if err != nil {
-				glog.Errorf("Failed to query metric %v [%v] for entity type %v: %v.",
-					metricKind, metricQuery, entityType, err)
-				continue
-			}
-			for _, metricData := range metricSeries {
-				basicMetricData, ok := metricData.(*prometheus.BasicMetricData)
-				if !ok {
-					// TODO: Enhance error messages
-					glog.Errorf("Type assertion failed for metricData %+v obtained from %v [%v] for entity type %v.",
-						metricData, metricKind, metricQuery, entityType)
-					continue
-				}
-				metricValue := basicMetricData.GetValue()
-				if math.IsNaN(metricValue) || math.IsInf(metricValue, 0) {
-					glog.Warningf("Invalid value for metricData %+v obtained from %v [%v] for entity type %v.",
-						metricData, metricKind, metricQuery, entityType)
-					continue
-				}
-				entityAttr, err := entityDef.reconcileAttributes(basicMetricData.Labels)
-				if err != nil {
-					glog.Errorf("Failed to reconcile attributes from labels %+v obtained from %v [%v] for entity %v: %v.",
-						basicMetricData.Labels, metricKind, metricQuery, entityType, err)
-					continue
-				}
-				difEntity, found := entityMetricsMap[entityAttr.id]
-				if !found {
-					difEntity = data.NewDIFEntity(entityAttr.id, entityType).
-						WithNamespace(entityAttr.namespace)
-					if entityAttr.ip != "" {
-						difEntity.Matching(entityAttr.ip)
-					}
-					if entityDef.hostedOnVM {
-						difEntity.HostedOnType(data.VM).HostedOnIP(entityAttr.ip)
-					}
-					processOwner(difEntity, entityAttr)
-					entityMetricsMap[entityAttr.id] = difEntity
-				}
-				// Process metrics
-				if difMetricValKind, ok := metricKindToDIFMetricValKind[metricKind]; ok {
-					glog.V(4).Infof("Processing %v, %v, %v",
-						difEntity.Name, metricType, difMetricValKind)
-					difEntity.AddMetric(metricType, difMetricValKind, basicMetricData.GetValue(), "")
-				}
+			for _, entityDef := range exporterDef.entityDefs {
+				// Dispatch the discovery task
+				tasks = append(tasks, NewTask(serverDef.promClient, entityDef))
 			}
 		}
 	}
-	for _, metric := range entityMetricsMap {
-		entityMetrics = append(entityMetrics, metric)
-	}
-	return entityMetrics
-}
-
-func processOwner(entity *data.DIFEntity, entityAttr *entityAttribute) {
-	if entityAttr.service != "" {
-		ServicePrefix := "Service-"
-		svcID := ServicePrefix + entity.UID
-		entity.PartOfEntity("service", svcID, entityAttr.service)
-	}
+	total := len(tasks)
+	glog.V(2).Infof("Total entity types to discover %v", total)
+	// Dispatch tasks in a separate goroutine to avoid deadlock
+	go func() {
+		for _, task := range tasks {
+			p.dispatcher.Dispatch(task)
+		}
+	}()
+	// Collect the result
+	return p.dispatcher.CollectResult(total), nil
 }

--- a/pkg/provider/task.go
+++ b/pkg/provider/task.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"github.com/golang/glog"
+	"github.com/turbonomic/prometurbo/pkg/prometheus"
+	"github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data"
+	"math"
+)
+
+type Task struct {
+	source    *prometheus.RestClient
+	entityDef *entityDef
+}
+
+func NewTask(source *prometheus.RestClient, entityDef *entityDef) *Task {
+	return &Task{
+		source:    source,
+		entityDef: entityDef,
+	}
+}
+
+// Implement the ITask Run() interface
+func (t *Task) Run() []*data.DIFEntity {
+	return t.getMetricsForEntity()
+}
+
+func (t *Task) getMetricsForEntity() []*data.DIFEntity {
+	promClient := t.source
+	entityDef := t.entityDef
+	var entityMetrics []*data.DIFEntity
+	var entityMetricsMap = map[string]*data.DIFEntity{}
+	for _, metricDef := range entityDef.metricDefs {
+		entityType := entityDef.eType
+		for metricKind, metricQuery := range metricDef.queries {
+			metricType := metricDef.mType
+			metricSeries, err := promClient.GetMetrics(metricQuery)
+			if err != nil {
+				glog.Errorf("Failed to query metric %v [%v] for entity type %v: %v.",
+					metricKind, metricQuery, entityType, err)
+				continue
+			}
+			for _, metricData := range metricSeries {
+				basicMetricData, ok := metricData.(*prometheus.BasicMetricData)
+				if !ok {
+					// TODO: Enhance error messages
+					glog.Errorf("Type assertion failed for metricData %+v obtained from %v [%v] for entity type %v.",
+						metricData, metricKind, metricQuery, entityType)
+					continue
+				}
+				metricValue := basicMetricData.GetValue()
+				if math.IsNaN(metricValue) || math.IsInf(metricValue, 0) {
+					glog.Warningf("Invalid value for metricData %+v obtained from %v [%v] for entity type %v.",
+						metricData, metricKind, metricQuery, entityType)
+					continue
+				}
+				entityAttr, err := entityDef.reconcileAttributes(basicMetricData.Labels)
+				if err != nil {
+					glog.Errorf("Failed to reconcile attributes from labels %+v obtained from %v [%v] for entity %v: %v.",
+						basicMetricData.Labels, metricKind, metricQuery, entityType, err)
+					continue
+				}
+				difEntity, found := entityMetricsMap[entityAttr.id]
+				if !found {
+					difEntity = data.NewDIFEntity(entityAttr.id, entityType).
+						WithNamespace(entityAttr.namespace)
+					if entityAttr.ip != "" {
+						difEntity.Matching(entityAttr.ip)
+					}
+					if entityDef.hostedOnVM {
+						difEntity.HostedOnType(data.VM).HostedOnIP(entityAttr.ip)
+					}
+					processOwner(difEntity, entityAttr)
+					entityMetricsMap[entityAttr.id] = difEntity
+				}
+				// Process metrics
+				if difMetricValKind, ok := metricKindToDIFMetricValKind[metricKind]; ok {
+					glog.V(4).Infof("Processing %v, %v, %v",
+						difEntity.Name, metricType, difMetricValKind)
+					difEntity.AddMetric(metricType, difMetricValKind, basicMetricData.GetValue(), "")
+				}
+			}
+		}
+	}
+	for _, metric := range entityMetricsMap {
+		entityMetrics = append(entityMetrics, metric)
+	}
+	return entityMetrics
+}
+
+func processOwner(entity *data.DIFEntity, entityAttr *entityAttribute) {
+	if entityAttr.service != "" {
+		ServicePrefix := "Service-"
+		svcID := ServicePrefix + entity.UID
+		entity.PartOfEntity("service", svcID, entityAttr.service)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,11 +55,13 @@ func (s *Server) Topology(topology *topology.BusinessTopology) *Server {
 }
 
 func (s *Server) Run() {
+	// Start the metric provider to launch dispatcher to dispatch discovery tasks
+	s.provider.Start()
+	// Start the http server to process discovery request
 	server := http.Server{
 		Addr:    fmt.Sprintf(":%d", s.port),
 		Handler: s,
 	}
-
 	glog.V(2).Infof("HTTP server listens on: %v:%v", s.ip, s.port)
 	panic(server.ListenAndServe())
 }

--- a/pkg/worker/collector.go
+++ b/pkg/worker/collector.go
@@ -1,0 +1,39 @@
+package worker
+
+import (
+	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data"
+	"sync"
+)
+
+type Collector struct {
+	resultPool chan []*data.DIFEntity
+}
+
+func NewCollector(maxWorkerNumber int) *Collector {
+	return &Collector{
+		resultPool: make(chan []*data.DIFEntity, maxWorkerNumber),
+	}
+}
+
+func (m *Collector) collect(count int) (mergedResult []*data.DIFEntity) {
+	stopChan := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(count)
+	go func() {
+		for {
+			select {
+			case <-stopChan:
+				return
+			case result := <-m.resultPool:
+				mergedResult = append(mergedResult, result...)
+				wg.Done()
+			}
+		}
+	}()
+	wg.Wait()
+	// stop the result waiting goroutine.
+	close(stopChan)
+	glog.V(2).Infof("Collected results from all %d tasks.", count)
+	return
+}

--- a/pkg/worker/dispatcher.go
+++ b/pkg/worker/dispatcher.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data"
+)
+
+type Dispatcher struct {
+	workerCount int
+	workerPool  chan chan ITask
+	collector   *Collector
+}
+
+func NewDispatcher(workerCount int) *Dispatcher {
+	return &Dispatcher{
+		workerCount: workerCount,
+		workerPool:  make(chan chan ITask, workerCount),
+	}
+}
+
+func (d *Dispatcher) WithCollector(collector *Collector) *Dispatcher {
+	d.collector = collector
+	return d
+}
+
+func (d *Dispatcher) Start() {
+	// Create workers
+	for i := 0; i < d.workerCount; i++ {
+		// Create and launch a worker in a separate goroutine
+		go d.launchWorker(fmt.Sprintf("%d", i))
+	}
+}
+
+func (d *Dispatcher) launchWorker(id string) {
+	worker := newWorker(id)
+	// Put the worker into the pool
+	d.workerPool <- worker.taskChan
+	for {
+		// Wait for a task to appear on the channel
+		select {
+		case t := <-worker.taskChan:
+			glog.V(2).Infof("worker %s has received a task.", worker.id)
+			result := worker.execute(t)
+			d.collector.resultPool <- result
+			glog.V(2).Infof("worker %s has finished.", worker.id)
+			d.workerPool <- worker.taskChan
+		}
+	}
+}
+
+// Dispatch a task, block when there is no free worker
+func (d *Dispatcher) Dispatch(t ITask) {
+	glog.V(4).Infof("Waiting for a free worker")
+	// Pick a free worker from the worker pool, when its channel frees up
+	taskChannel := <-d.workerPool
+	// Assign a task to the worker
+	taskChannel <- t
+}
+
+// Collect results from this round of discovery
+func (d *Dispatcher) CollectResult(taskCount int) []*data.DIFEntity {
+	return d.collector.collect(taskCount)
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -1,0 +1,23 @@
+package worker
+
+import "github.com/turbonomic/turbo-go-sdk/pkg/dataingestionframework/data"
+
+type ITask interface {
+	Run() []*data.DIFEntity
+}
+
+type worker struct {
+	id       string
+	taskChan chan ITask
+}
+
+func newWorker(id string) *worker {
+	return &worker{
+		id:       id,
+		taskChan: make(chan ITask),
+	}
+}
+
+func (w *worker) execute(task ITask) []*data.DIFEntity {
+	return task.Run()
+}


### PR DESCRIPTION
This PR implements support for concurrent discovery of metrics via goroutine. 

By nature of the entity definitions in `prometheus-config.yaml`, the queries to the Prometheus server can be parallelized based on prometheus URL, exporter and entity definition combination. For example, the following queries are independent of each other, and can be made in parallel:
```
- http://prometheus-server.turbonomic:9090, turbonomic, businessTransaction-http
- http://prometheus-server.turbonomic:9090, turbonomic, businessTransaction-grpc
- http://prometheus-server.turbonomic:9090, turbonomic, application
- http://prometheus-server.turbonomic:9090, turbonomic, databaseServer
- http://prometheus.istio-system:9090, istio, application
```

This PR creates a worker pool (default 4 workers) to process prometheus queries in parallel, and merge the results from individual workers. Tests indicate that the total query time can be cut down by half for `turbonomic` exporter with default 4 workers.
```
I0713 15:50:28.390830       1 provider.go:51] Total entity types to discover 4
I0713 15:50:28.390887       1 dispatcher.go:43] worker 1 has received a task.
I0713 15:50:28.391307       1 dispatcher.go:43] worker 2 has received a task.
I0713 15:50:28.391406       1 dispatcher.go:43] worker 3 has received a task.
I0713 15:50:28.391477       1 dispatcher.go:43] worker 0 has received a task.
I0713 15:50:28.413288       1 dispatcher.go:46] worker 3 has finished.
I0713 15:50:28.453145       1 dispatcher.go:46] worker 1 has finished.
I0713 15:50:28.453518       1 dispatcher.go:46] worker 2 has finished.
I0713 15:50:28.531311       1 dispatcher.go:46] worker 0 has finished.
I0713 15:50:28.531355       1 collector.go:37] Collected results from all 4 tasks.
I0713 15:50:28.531366       1 handler.go:158] Discovered 128 entities.
I0713 15:50:28.598666       1 topology.go:44] Created 1 services for market [cisco]
I0713 15:50:28.598880       1 topology.go:44] Created 1 services for group [cisco]
I0713 15:50:28.598980       1 topology.go:44] Created 1 services for topology-processor [cisco
...
```