### PR TITLE
Add ignoreCommodityIfPresent to prometurbo operator and helm deployment

### DIFF
--- a/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1alpha1_prometurbo_cr.yaml
+++ b/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1alpha1_prometurbo_cr.yaml
@@ -38,3 +38,10 @@ spec:
   # The Target Type will appear as DataIngestionFramework-<targetTypeSuffix> on the UI
   # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
   #targetTypeSuffix: Prometheus
+
+  # Command line arguments
+  args:
+    # Logging level 2 to 4
+    logginglevel: 2
+    # When set to true, ignore merging a commodity if a commodity of the same type already exists
+    #ignoreCommodityIfPresent: false

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --v={{ .Values.args.logginglevel }}
+  {{- if .Values.args.ignoreCommodityIfPresent }}
+            - --ignoreCommodityIfPresent=true
+  {{- end }}
           volumeMounts:
           - name: turbodif-config
             mountPath: /etc/turbodif

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -5,9 +5,9 @@
 # Replace the image with desired version
 image:
   prometurboRepository: turbonomic/prometurbo
-  prometurboTag: 8.3.2
+  prometurboTag: 8.4.4
   turbodifRepository: turbonomic/turbodif
-  turbodifTag: 8.3.2
+  turbodifTag: 8.4.4
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -38,6 +38,8 @@ targetTypeSuffix: Prometheus
 args:
   # logging level
   logginglevel: 2
+  # When set to true, ignore merging a commodity if a commodity of the same type already exists
+  ignoreCommodityIfPresent: false
 
 # Prometheus servers and metrics to scrape
 prometheusServers: |

--- a/deploy/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --v={{ .Values.args.logginglevel }}
+  {{- if .Values.args.ignoreCommodityIfPresent }}
+            - --ignoreCommodityIfPresent=true
+  {{- end }}
           volumeMounts:
           - name: turbodif-config
             mountPath: /etc/turbodif

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -5,9 +5,9 @@
 # Replace the image with desired version
 image:
   prometurboRepository: turbonomic/prometurbo
-  prometurboTag: 8.1.2
+  prometurboTag: 8.4.4
   turbodifRepository: turbonomic/turbodif
-  turbodifTag: 8.1.2
+  turbodifTag: 8.4.4
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -38,6 +38,8 @@ targetTypeSuffix: Prometheus
 args:
   # logging level
   logginglevel: 2
+  # When set to true, ignore merging a commodity if a commodity of the same type already exists
+  ignoreCommodityIfPresent: false
 
 # Prometheus servers and metrics to scrape
 prometheusServers: |


### PR DESCRIPTION
This PR adds `ignoreCommodityIfPresent` command line option to:

*  Prometurbo operator deployment
*  Prometurbo helm deployment

For example:

```yaml
args:
  # logging level
  logginglevel: 2
  # When set to true, ignore merging a commodity if a commodity of the same type already exists
  ignoreCommodityIfPresent: true
```
