### PR TITLE
[OM-88664]: Fixed scale for node memory query.

### DIFF
--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-prometurbo.yaml
@@ -119,7 +119,7 @@ data:
                   used: 'sum by (instance, job) (irate(node_cpu_seconds_total{}[3m]))'
               - type: memory
                 queries:
-                  used: 'node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{}'
+                  used: '(node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{})/1024'
             attributes:
               ip:
                 label: instance

--- a/deploy/prometurbo/templates/configmap-prometurbo.yaml
+++ b/deploy/prometurbo/templates/configmap-prometurbo.yaml
@@ -119,7 +119,7 @@ data:
                   used: 'sum by (instance, job) (irate(node_cpu_seconds_total{}[3m]))'
               - type: memory
                 queries:
-                  used: 'node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{}'
+                  used: '(node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{})/1024'
             attributes:
               ip:
                 label: instance

--- a/deploy/prometurbo_yamls/configmap-prometurbo.yaml
+++ b/deploy/prometurbo_yamls/configmap-prometurbo.yaml
@@ -128,7 +128,7 @@ data:
                   used: 'sum by (instance, job) (irate(node_cpu_seconds_total{}[3m]))'
               - type: memory
                 queries:
-                  used: 'node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{}'
+                  used: '(node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{})/1024'
             attributes:
               ip:
                 label: instance


### PR DESCRIPTION
## Intent

Fix the unit scale for the node memory query to fix extremely high utilization values when Prometurbo data is stitched.

## Background

When Prometurbo is running in a stitched environment with the node exporter running, we've received reports of extremely high utilization values. These appear to be the result of the units in the node query being off.

Prometurbo registers with the _Custom_ probe category, while Kubeturbo registers with the _Cloud Native_ category. During the stitching phase, probes with the _Custom_ category stitch last, which results in the Prometurbo data being retained. Since the scale of the query result is off, we see extremely high utilization when this happens.

We fixed once instance of this in a [previous PR](https://github.com/turbonomic/prometurbo/pull/76/files), but must've missed the one included here, as it's occurred in a customer's installation again.

The goal here is to try to prevent this from happening in a customer environment when using our default configs.

## Testing

Deployed Kubeturbo and Prometurbo instances to the _ae-cluster2_, proxied to my appliance. 

Verified that, with the original query, I see the extremely high utilization:

![OM-88664_before](https://user-images.githubusercontent.com/97479009/188688565-dfa9bad9-8d6d-4e9c-8599-6a57ed7f78ca.png)

Verified that utilization values drop to normal levels with the updated query:

![OM-88664_after](https://user-images.githubusercontent.com/97479009/188688583-2ea30494-4034-409e-9d46-a1a647ec3d41.png)

