### PR TITLE
[OM-91935 ]Multiarch docker image support changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-       # Update docker
+      if [ -n "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" == "master" ]; then
+        # Update docker
         sudo rm -rf /var/lib/apt/lists/*
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
@@ -42,11 +43,12 @@ after_success:
         docker buildx create --use
         # Build and push the image
         cd build
-      if [ -n "$TRAVIS_TAG" ]; then
-          # Push a release image triggered by a git tag
-          docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
-      elif [ "$TRAVIS_BRANCH" == "master" ]; then
-          # Push the latest image built from master branch
-          docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
+        if [ -n "$TRAVIS_TAG" ]; then
+            # Push a release image triggered by a git tag
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
+        else
+            # Push the latest image built from master branch
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
+        fi
       fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 env:
   global:
     - DOCKER_IMAGE_NAME=$TRAVIS_REPO_SLUG
+    - PLATFORM_OS_ARCH_LIST="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
 
 services:
   - docker
@@ -20,19 +21,32 @@ script:
   - make vet
   - make product
   - $HOME/gopath/bin/goveralls -v -race -service=travis-ci
-  - cd build
-  - docker build -t $DOCKER_IMAGE_NAME --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
 
 after_success:
   - |
     if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+       # Update docker
+        sudo rm -rf /var/lib/apt/lists/*
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) edge"
+        sudo apt-get update
+        sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+        docker version
+        # Install buildx plugin
+        mkdir -vp ~/.docker/cli-plugins/
+        curl --silent -L "https://github.com/docker/buildx/releases/download/v0.6.0/buildx-v0.6.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+        chmod a+x ~/.docker/cli-plugins/docker-buildx
+        # Login to docker
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        # Create and set a new buildx builder instance
+        docker buildx create --use
+        # Build and push the image
+        cd build
       if [ -n "$TRAVIS_TAG" ]; then
           # Push a release image triggered by a git tag
-          docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE_NAME:$TRAVIS_TAG
-          docker push $DOCKER_IMAGE_NAME:$TRAVIS_TAG
+          docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
       elif [ "$TRAVIS_BRANCH" == "master" ]; then
           # Push the latest image built from master branch
-          docker push $DOCKER_IMAGE_NAME
+          docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
       fi
     fi

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,43 @@
 OUTPUT_DIR=build
 SOURCE_DIRS = cmd pkg
 PACKAGES := go list ./... | grep -v /vendor | grep -v /out
+SHELL='/bin/bash'
+REMOTE=github.com
+USER=turbonomic
+PROJECT=prometurbo
+bin=prometurbo
+DEFAULT_VERSION=latest 
 
 .DEFAULT_GOAL := build
 
-bin=prometurbo
-product: clean fmtcheck vet
-	env GOOS=linux GOARCH=amd64 go build -o ${OUTPUT_DIR}/${bin}.linux ./cmd
+
+GIT_COMMIT=$(shell git rev-parse --short HEAD)
+BUILD_TIME=$(shell date -R)
+PROJECT_PATH=$(REMOTE)/$(USER)/$(PROJECT)
+VERSION=$(or $(PROMETURBO_VERSION), $(DEFAULT_VERSION))
+LDFLAGS='\
+ -X "$(PROJECT_PATH)/version.GitCommit=$(GIT_COMMIT)" \
+ -X "$(PROJECT_PATH)/version.BuildTime=$(BUILD_TIME)" \
+ -X "$(PROJECT_PATH)/version.Version=$(VERSION)"'
+
+LINUX_ARCH=amd64 arm64 ppc64le s390x
+
+$(LINUX_ARCH): clean
+	env GOOS=linux GOARCH=$@ go build -ldflags $(LDFLAGS) -o $(OUTPUT_DIR)/linux/$@/$(bin) ./cmd
+
+product: $(LINUX_ARCH)
 
 debug-product: clean
-	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags "-N -l" -o ${OUTPUT_DIR}/${bin}_debug.linux ./cmd
+	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -gcflags "-N -l" -o ${OUTPUT_DIR}/${bin}_debug ./cmd
 
 build: clean
-	go build -o ${bin} ./cmd
+	go build -ldflags $(LDFLAGS) -o ${bin} ./cmd
 
 debug: clean
 	go build -gcflags "-N -l" -o ${bin}.debug ./cmd
 
 docker: product
-	cd build; docker build -t turbonomic/prometurbo --build-arg GIT_COMMIT=$(shell git rev-parse --short HEAD) .
+	cd build; docker build -t turbonomic/prometurbo --build-arg $(GIT_COMMIT) .
 
 test: clean
 	@go test -v -race ./pkg/...
@@ -32,4 +51,4 @@ vet:
 	@go vet $(shell $(PACKAGES))
 
 clean:
-	@rm -rf ${OUTPUT_DIR}/${bin}.linux ${bin}
+	@rm -rf ${OUTPUT_DIR}/linux ${bin}

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ build: clean
 	go build -ldflags $(LDFLAGS) -o ${bin} ./cmd
 
 debug: clean
-	go build -gcflags "-N -l" -o ${bin}.debug ./cmd
+	go build -ldflags $(LDFLAGS) -gcflags "-N -l" -o ${bin}.debug ./cmd
 
 docker: product
-	cd build; docker build -t turbonomic/prometurbo --build-arg $(GIT_COMMIT) .
+	cd build; DOCKER_BUILDKIT=1 docker build -t turbonomic/prometurbo --build-arg $(GIT_COMMIT) .
 
 test: clean
 	@go test -v -race ./pkg/...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8-minimal
 MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
 ARG GIT_COMMIT
+ARG TARGETPLATFORM
 ENV GIT_COMMIT ${GIT_COMMIT}
 
 ### Atomic/OpenShift Labels - https://github.com/projectatomic/ContainerApplicationGenericLabels
@@ -28,7 +29,7 @@ ENV APP_ROOT=/opt/turbonomic
 ENV PATH=$PATH:${APP_ROOT}/bin
 
 RUN mkdir -p ${APP_ROOT}/bin
-COPY prometurbo.linux ${APP_ROOT}/bin/prometurbo
+COPY ${TARGETPLATFORM}/prometurbo ${APP_ROOT}/bin/prometurbo
 RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
     chmod -R g=u ${APP_ROOT}
 


### PR DESCRIPTION
This PR supports building a multi-arch manifest images of prometurbo that has multiple images supporting different architectures


**Changes:**

1. Update the product target in the Makefile to produce binaries that supports linux/amd64, linux/arm64, linux/ppc64le and linux/s390x OS/Arch combinations respectively.
- Add buildkit flag to ensure builds without buildx pre-installed


2. Update the Dockerfile to copy appropriate binary using the built-in TARGETPLATFORM environment variable supported by docker build

3. Update .travis.yml to build docker image with master branch and release tag builds
- Install docker buildx plugin. 
- Create a new buildx instance, build and push the image


**Test**

- Building multi-arch manifest images of prometurbo


<img width="1715" alt="Screen Shot 2022-10-26 at 10 09 32 PM" src="https://user-images.githubusercontent.com/112518353/198182719-7cdf05e3-457a-467c-8fbe-bd22b899326b.png">


Creating prometurbo community operator in OCP on multi-arch

<img width="1711" alt="Screen Shot 2022-10-26 at 10 10 17 PM" src="https://user-images.githubusercontent.com/112518353/198182968-a1b36f6c-0603-4f3d-aca7-8d50ae3c31d4.png">



<img width="1714" alt="Screen Shot 2022-10-26 at 10 10 34 PM" src="https://user-images.githubusercontent.com/112518353/198182989-90783fcd-82bb-4e1c-a6ad-c46fbd6ba85c.png">
