### PR TITLE
OM-93274 - Remove docker push image step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ after_success:
         cd build
         if [ -n "$TRAVIS_TAG" ]; then
             # Push a release image triggered by a git tag
-            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME:$TRAVIS_TAG .
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
         else
             # Push the latest image built from master branch
-            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" --push -t $DOCKER_IMAGE_NAME .
+            docker buildx build --platform $PLATFORM_OS_ARCH_LIST --build-arg GIT_COMMIT=$TRAVIS_COMMIT --label "git-version=$TRAVIS_COMMIT" .
         fi
       fi
     fi


### PR DESCRIPTION
Intent
Removal of docker push image step to docker repository in travis CI file as this step is not required after building the multi-arch manifest images. To publish multi-arch images to docker repository there is other jenkins script that's already in place

Testing
This was tested on local machine by following below steps:

- run make product from root folder, this builds multi-arch images
- run docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --label "#label-name" from build folder