### PR TITLE
[OM-93683] Fix security vulnerability CVE-2022-42898

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8-minimal
-MAINTAINER Enlin Xu <enlin.xu@turbonomic.com>
+MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
 ARG GIT_COMMIT
 ARG TARGETPLATFORM
 ENV GIT_COMMIT ${GIT_COMMIT}
@@ -13,11 +13,12 @@ LABEL name="Prometurbo Container" \
       description="Prometurbo Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure." \
 ### Required labels above - recommended below
       url="https://www.turbonomic.com" \
-      run='docker run -tdi --name ${NAME} vmturbo/prometurbo:latest' \
       io.k8s.description="Prometurbo Container will monitor and control the entire stack, from OpenShift down to your underlying infrastructure. " \
       io.k8s.display-name="Prometurbo Container" \
       io.openshift.expose-services="" \
       io.openshift.tags="turbonomic, Multicloud Container"
+
+RUN microdnf update -y krb5-libs
 
 ### add licenses to this directory
 COPY licenses /licenses

--- a/deploy/prometurbo-operator/Dockerfile
+++ b/deploy/prometurbo-operator/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/operator-framework/helm-operator:v1.25
-MAINTAINER Meng Ding <meng.ding@turbonomic.com>
+MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
 
 # Required OpenShift Labels
 LABEL name="Prometurbo Operator" \
@@ -10,11 +10,14 @@ LABEL name="Prometurbo Operator" \
       description="This operator will deploy an instance of prometurbo." \
 ### Required labels above - recommended below
       url="https://www.turbonomic.com" \
-      run='docker run -tdi --name ${NAME} turbonomic/prometurbo-operator:8.6.1' \
       io.k8s.description="Turbonomic Workload Automation Platform simultaneously optimizes performance, compliance, and cost in real-time. Workloads are precisely resourced, automatically, to perform while satisfying business constraints.  " \
       io.k8s.display-name="Prometurbo Operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="turbonomic, Multicloud Container"
+
+USER root
+RUN microdnf update -y krb5-libs
+USER ${USER_UID}
 
 # Required Licenses
 COPY licenses /licenses

--- a/deploy/prometurbo-operator/Makefile
+++ b/deploy/prometurbo-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 8.6.1
+VERSION ?= 8.7.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
This PR fixes [CVE-2022-42898](https://access.redhat.com/security/cve/CVE-2022-42898) by:

* Updating `krb5-libs` in `prometurbo`  image
* Updating `krb5-libs` in `prometurbo-operator` image

This PR also updates MAINTAINER and removes outdated labels.