### PR TITLE
[OM-93337]: update prometurbo yaml to pull image from icr.io

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -113,7 +113,8 @@ spec:
         app: prometurbo
     spec:
       containers:
-        - image: turbonomic/prometurbo
+        # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.io
+        - image: icr.io/cpopen/turbonomic/prometurbo:8.6.3
           imagePullPolicy: IfNotPresent
           name: prometurbo
           args:
@@ -125,7 +126,8 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-          image: turbonomic/turbodif
+          # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.io
+          image: icr.io/cpopen/turbonomic/turbodif:8.6.3
           imagePullPolicy: IfNotPresent
           args:
             - --v=2

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -113,8 +113,8 @@ spec:
         app: prometurbo
     spec:
       containers:
-        # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.io
-        - image: icr.io/cpopen/turbonomic/prometurbo:8.6.3
+        # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
+        - image: icr.io/cpopen/turbonomic/prometurbo:8.7.3
           imagePullPolicy: IfNotPresent
           name: prometurbo
           args:
@@ -126,8 +126,8 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-          # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.io
-          image: icr.io/cpopen/turbonomic/turbodif:8.6.3
+          # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
+          image: icr.io/cpopen/turbonomic/turbodif:8.7.3
           imagePullPolicy: IfNotPresent
           args:
             - --v=2

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -113,8 +113,8 @@ spec:
         app: prometurbo
     spec:
       containers:
-        # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
-        - image: icr.io/cpopen/turbonomic/prometurbo:8.7.3
+        # Replace the image with desired version:8.7.5 or snapshot version:8.7.5-SNAPSHOT from icr.io
+        - image: icr.io/cpopen/turbonomic/prometurbo:8.7.5
           imagePullPolicy: IfNotPresent
           name: prometurbo
           args:
@@ -126,8 +126,8 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-          # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
-          image: icr.io/cpopen/turbonomic/turbodif:8.7.3
+          # Replace the image with desired version:8.7.5 or snapshot version:8.7.5-SNAPSHOT from icr.io
+          image: icr.io/cpopen/turbonomic/turbodif:8.7.5
           imagePullPolicy: IfNotPresent
           args:
             - --v=2

--- a/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_prometurbos_crd.yaml
+++ b/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_prometurbos_crd.yaml
@@ -51,13 +51,13 @@ spec:
               description: Prometurbo image details for deployments outside of RH Operator Hub
               properties:
                 prometurboRepository:
-                  description: Container repository. default is docker hub
+                  description: Container repository. default is icr.io/cpopen/turbonomic/prometurbo
                   type: string
                 prometurboTag:
                   description: Prometurbo container image tag
                   type: string
                 turbodifRepository:
-                  description: Container repository. default is docker hub
+                  description: Container repository. default is icr.io/cpopen/turbonomic/turbodif
                   type: string
                 turbodifTag:
                   description: Turbodif container image tag

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-{{- if and .Values.image.relatedprome (eq .Values.image.prometurboRepository "turbonomic/prometurbo") }}
+{{- if and .Values.image.relatedprome (eq .Values.image.prometurboRepository "icr.io/cpopen/turbonomic/prometurbo") }}
           image: {{ .Values.image.relatedprome }}
 {{- else }}
           image: {{ .Values.image.prometurboRepository }}:{{ .Values.image.prometurboTag }}
@@ -46,7 +46,7 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-{{- if and .Values.image.relatedturbo (eq .Values.image.turbodifRepository "turbonomic/turbodif") }}
+{{- if and .Values.image.relatedturbo (eq .Values.image.turbodifRepository "icr.io/cpopen/turbonomic/turbodif") }}
           image: {{ .Values.image.relatedturbo }}
 {{- else }}
           image: {{ .Values.image.turbodifRepository }}:{{ .Values.image.turbodifTag }}

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -6,10 +6,10 @@ replicaCount: 1
 
 # Replace the image with desired version
 image:
-  prometurboRepository: turbonomic/prometurbo
-  prometurboTag: 8.6.0
-  turbodifRepository: turbonomic/turbodif
-  turbodifTag: 8.6.0
+  prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
+  prometurboTag: 8.6.3
+  turbodifRepository: icr.io/cpopen/turbonomic/turbodif
+  turbodifTag: 8.6.3
   pullPolicy: IfNotPresent
 
 #nameOverride: ""

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -7,9 +7,9 @@ replicaCount: 1
 # Replace the image with desired version
 image:
   prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
-  prometurboTag: 8.7.3
+  prometurboTag: 8.7.5
   turbodifRepository: icr.io/cpopen/turbonomic/turbodif
-  turbodifTag: 8.7.3
+  turbodifTag: 8.7.5
   pullPolicy: IfNotPresent
 
 #nameOverride: ""

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -7,9 +7,9 @@ replicaCount: 1
 # Replace the image with desired version
 image:
   prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
-  prometurboTag: 8.6.3
+  prometurboTag: 8.7.3
   turbodifRepository: icr.io/cpopen/turbonomic/turbodif
-  turbodifTag: 8.6.3
+  turbodifTag: 8.7.3
   pullPolicy: IfNotPresent
 
 #nameOverride: ""

--- a/deploy/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-{{- if and .Values.image.relatedprome (eq .Values.image.prometurboRepository "turbonomic/prometurbo") }}
+{{- if and .Values.image.relatedprome (eq .Values.image.prometurboRepository "icr.io/cpopen/turbonomic/prometurbo") }}
           image: {{ .Values.image.relatedprome }}
 {{- else }}
           image: {{ .Values.image.prometurboRepository }}:{{ .Values.image.prometurboTag }}
@@ -46,7 +46,7 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-{{- if and .Values.image.relatedturbo (eq .Values.image.turbodifRepository "turbonomic/turbodif") }}
+{{- if and .Values.image.relatedturbo (eq .Values.image.turbodifRepository "icr.io/cpopen/turbonomic/turbodif") }}
           image: {{ .Values.image.relatedturbo }}
 {{- else }}
           image: {{ .Values.image.turbodifRepository }}:{{ .Values.image.turbodifTag }}

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -4,12 +4,12 @@
 
 replicaCount: 1
 
-# Replace the image with desired version
+# Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
 image:
-  prometurboRepository: turbonomic/prometurbo
-  prometurboTag: 8.6.0
-  turbodifRepository: turbonomic/turbodif
-  turbodifTag: 8.6.0
+  prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
+  prometurboTag: 8.7.3
+  turbodifRepository: icr.io/cpopen/turbonomic/turbodif
+  turbodifTag: 8.7.3
   pullPolicy: IfNotPresent
 
 #nameOverride: ""

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -4,12 +4,12 @@
 
 replicaCount: 1
 
-# Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
+# Replace the image with desired version:8.7.5 or snapshot version:8.7.5-SNAPSHOT from icr.io
 image:
   prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
-  prometurboTag: 8.7.3
+  prometurboTag: 8.7.5
   turbodifRepository: icr.io/cpopen/turbonomic/turbodif
-  turbodifTag: 8.7.3
+  turbodifTag: 8.7.5
   pullPolicy: IfNotPresent
 
 #nameOverride: ""

--- a/deploy/prometurbo_yamls/deployment.yaml
+++ b/deploy/prometurbo_yamls/deployment.yaml
@@ -15,8 +15,8 @@ spec:
         app: prometurbo
     spec:
       containers:
-        # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.i
-        - image: icr.io/cpopen/turbonomic/prometurbo:8.63
+        # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.i
+        - image: icr.io/cpopen/turbonomic/prometurbo:8.7.3
           imagePullPolicy: IfNotPresent
           name: prometurbo
           args:
@@ -28,8 +28,8 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-          # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.io
-          image: icr.io/cpopen/turbonomic/turbodif:8.6.3
+          # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
+          image: icr.io/cpopen/turbonomic/turbodif:8.7.3
           imagePullPolicy: IfNotPresent
           args:
             - --v=2

--- a/deploy/prometurbo_yamls/deployment.yaml
+++ b/deploy/prometurbo_yamls/deployment.yaml
@@ -15,7 +15,8 @@ spec:
         app: prometurbo
     spec:
       containers:
-        - image: turbonomic/prometurbo
+        # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.i
+        - image: icr.io/cpopen/turbonomic/prometurbo:8.63
           imagePullPolicy: IfNotPresent
           name: prometurbo
           args:
@@ -27,7 +28,8 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-          image: turbonomic/turbodif
+          # Replace the image with desired version:8.6.3 or snapshot version:8.7.3-SNAPSHOT from icr.io
+          image: icr.io/cpopen/turbonomic/turbodif:8.6.3
           imagePullPolicy: IfNotPresent
           args:
             - --v=2

--- a/deploy/prometurbo_yamls/deployment.yaml
+++ b/deploy/prometurbo_yamls/deployment.yaml
@@ -15,8 +15,8 @@ spec:
         app: prometurbo
     spec:
       containers:
-        # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.i
-        - image: icr.io/cpopen/turbonomic/prometurbo:8.7.3
+        # Replace the image with desired version:8.7.5 or snapshot version:8.7.5-SNAPSHOT from icr.i
+        - image: icr.io/cpopen/turbonomic/prometurbo:8.7.5
           imagePullPolicy: IfNotPresent
           name: prometurbo
           args:
@@ -28,8 +28,8 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-          # Replace the image with desired version:8.7.3 or snapshot version:8.7.4-SNAPSHOT from icr.io
-          image: icr.io/cpopen/turbonomic/turbodif:8.7.3
+          # Replace the image with desired version:8.7.5 or snapshot version:8.7.5-SNAPSHOT from icr.io
+          image: icr.io/cpopen/turbonomic/turbodif:8.7.5
           imagePullPolicy: IfNotPresent
           args:
             - --v=2


### PR DESCRIPTION
update prometurbo yaml to pull image from icr.io.

➜  ~ skopeo list-tags docker://icr.io/cpopen/turbonomic/turbodif
{
    "Repository": "icr.io/cpopen/turbonomic/turbodif",
    "Tags": [
        "8.6.3",
        "8.6.4",
        "8.6.5",
        "8.6.6",
        "8.7.0",
        "8.7.1",
        "8.7.2-SNAPSHOT",
        "8.7.2",
        "8.7.3-SNAPSHOT",
        "8.7.3",
        "8.7.4-SNAPSHOT"
    ]
}
➜  ~ skopeo list-tags docker://icr.io/cpopen/turbonomic/prometurbo

{
    "Repository": "icr.io/cpopen/turbonomic/prometurbo",
    "Tags": [
        "8.6.3",
        "8.6.4",
        "8.6.5",
        "8.6.6",
        "8.7.0",
        "8.7.1",
        "8.7.2-SNAPSHOT",
        "8.7.2",
        "8.7.3-SNAPSHOT",
        "8.7.3",
        "8.7.4-SNAPSHOT"
    ]
}