### PR TITLE
[OM-95987] Allow changing image tag with certified prometurbo-operator

### DIFF
--- a/deploy/prometurbo-operator/Dockerfile
+++ b/deploy/prometurbo-operator/Dockerfile
@@ -1,26 +1,32 @@
 FROM quay.io/operator-framework/helm-operator:v1.25
 MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
+ARG VERSION
+
+RUN echo "Building prometurbo-operator:$VERSION"
 
 # Required OpenShift Labels
 LABEL name="Prometurbo Operator" \
-      vendor="Turbonomic" \
-      version="8" \
-      release="6" \
+      vendor="IBM" \
+      version=$VERSION \
+      release=$VERSION \
       summary="This is the prometurbo operator." \
       description="This operator will deploy an instance of prometurbo." \
 ### Required labels above - recommended below
-      url="https://www.turbonomic.com" \
+      url="https://www.ibm.com/products/turbonomic" \
       io.k8s.description="Turbonomic Workload Automation Platform simultaneously optimizes performance, compliance, and cost in real-time. Workloads are precisely resourced, automatically, to perform while satisfying business constraints.  " \
       io.k8s.display-name="Prometurbo Operator" \
       io.openshift.expose-services="" \
       io.openshift.tags="turbonomic, Multicloud Container"
 
 USER root
+# Update security library
 RUN microdnf update -y krb5-libs
-USER ${USER_UID}
-
 # Required Licenses
 COPY licenses /licenses
-
+# Copy helm charts
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/
+# Set default version number
+RUN sed -i "s/VERSION/$VERSION/g" ${HOME}/helm-charts/prometurbo/values.yaml
+# Change user
+USER ${USER_UID}

--- a/deploy/prometurbo-operator/Makefile
+++ b/deploy/prometurbo-operator/Makefile
@@ -3,7 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 8.7.2
+DEFAULT_VERSION=8.8.0
+VERSION=$(or $(PROMETURBO_VERSION), $(DEFAULT_VERSION))
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -66,7 +67,7 @@ run: helm-operator ## Run against the configured Kubernetes cluster in ~/.kube/c
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg VERSION=${VERSION} -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/deployment.yaml
@@ -29,11 +29,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-{{- if and .Values.image.relatedprome (eq .Values.image.prometurboRepository "icr.io/cpopen/turbonomic/prometurbo") }}
-          image: {{ .Values.image.relatedprome }}
-{{- else }}
           image: {{ .Values.image.prometurboRepository }}:{{ .Values.image.prometurboTag }}
-{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --v={{ .Values.args.logginglevel }}
@@ -46,11 +42,7 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-{{- if and .Values.image.relatedturbo (eq .Values.image.turbodifRepository "icr.io/cpopen/turbonomic/turbodif") }}
-          image: {{ .Values.image.relatedturbo }}
-{{- else }}
           image: {{ .Values.image.turbodifRepository }}:{{ .Values.image.turbodifTag }}
-{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --v={{ .Values.args.logginglevel }}

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -7,9 +7,9 @@ replicaCount: 1
 # Replace the image with desired version
 image:
   prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
-  prometurboTag: 8.7.5
+  prometurboTag: VERSION
   turbodifRepository: icr.io/cpopen/turbonomic/turbodif
-  turbodifTag: 8.7.5
+  turbodifTag: VERSION
   pullPolicy: IfNotPresent
 
 #nameOverride: ""
@@ -17,7 +17,7 @@ image:
 
 # Turbonomic server version and address
 serverMeta:
-  version: 8.3
+  version: VERSION
   turboServer: https://Turbo_server_URL
 
 # Turbonomic server api user and password

--- a/deploy/prometurbo/templates/deployment.yaml
+++ b/deploy/prometurbo/templates/deployment.yaml
@@ -29,11 +29,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-{{- if and .Values.image.relatedprome (eq .Values.image.prometurboRepository "icr.io/cpopen/turbonomic/prometurbo") }}
-          image: {{ .Values.image.relatedprome }}
-{{- else }}
           image: {{ .Values.image.prometurboRepository }}:{{ .Values.image.prometurboTag }}
-{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --v={{ .Values.args.logginglevel }}
@@ -46,11 +42,7 @@ spec:
               mountPath: /etc/prometurbo
               readOnly: true
         - name: turbodif
-{{- if and .Values.image.relatedturbo (eq .Values.image.turbodifRepository "icr.io/cpopen/turbonomic/turbodif") }}
-          image: {{ .Values.image.relatedturbo }}
-{{- else }}
           image: {{ .Values.image.turbodifRepository }}:{{ .Values.image.turbodifTag }}
-{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --v={{ .Values.args.logginglevel }}


### PR DESCRIPTION
## Background

After switching to `kubeturbo` image registry to `icr.io`, user cannot change the `prometurbo` and `turbodif` version using the `icr.io/cpopen/turbonomic` repository. This is a critical issue as user cannot change version to match with old server version.

## Solution

* Remove the logic to set hardcoded image digest for `prometurbo` and `turbodif` images
* Allow build script to set default `prometurboTag` and `turbodifTag` in `values.yaml`

With the above changes, the build script should specify a `VERSION` build argument when building `prometurbo-operator` container image, for example:

```
docker buildx build --platform "linux/amd64,linux/arm64,linux/ppc64le,linux/s390x" --build-arg VERSION=8.8.0 --push -t icr.io/cpopen/turbonomic/prometurbo-operator:8.8.0 .
```

The `Dockerfile` will replace the `VERSION` placeholder in the `values.yaml` file with the provided build argument.

## Test
* Deploy the dev build `prometurbo-operator` and verify updating image tag:
```
  image:
    prometurboTag: 8.7.6
    turbodifTag: 8.7.6
```
* Verify the correct containers are used:
```
  containerStatuses:
  - containerID: docker://8e7265b4f9fd9361dcdab8ad11f1e3301e9bd5802c53c5cf6773c6a20972162d
    image: icr.io/cpopen/turbonomic/prometurbo:8.7.6
    imageID: docker-pullable://icr.io/cpopen/turbonomic/prometurbo@sha256:66340912b049134c4ba6fe8dfdfb2d183bd9ded5007b67915096ddd8cce8ae56
    lastState: {}
    name: prometurbo
    ready: true
    restartCount: 0
    started: true
    state:
      running:
        startedAt: "2023-02-03T20:37:46Z"
  - containerID: docker://c196db48716a8bd7db1219ba2f6da403a5a9a25081670473a5ea6bef347ef459
    image: icr.io/cpopen/turbonomic/turbodif:8.7.6
    imageID: docker-pullable://icr.io/cpopen/turbonomic/turbodif@sha256:d864296e0cbf9094ab1d66aabbfe733904582180f3800c056a68f8f39b32891b
    lastState: {}
    name: turbodif
    ready: true
    restartCount: 0
    started: true
    state:
      running:

```