### PR TITLE
[OM-98404] Add missing serviceaccount file to prometurbo deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 *.iml
 .DS_Store
-build/prometurbo.linux
-prometurbo
+build/prometurbo*
 .vscode/

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/serviceaccount.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/serviceaccount.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccountName }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.roleName }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.turbonomic.io
+    resources:
+      - prometheusquerymappings
+      - prometheusserverconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+---
+kind: ClusterRoleBinding
+# For OpenShift 3.4-3.7 use apiVersion: v1
+# For kubernetes 1.9 use rbac.authorization.k8s.io/v1
+# For kubernetes 1.8 use rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.roleBinding }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  # User creating this resource must have permissions to add this policy to the SA
+  kind: ClusterRole
+  # accepted values cluster-reader disc and monitoring.
+  name: {{ .Values.roleName }}
+  # For OpenShift v3.4 remove apiGroup line
+  apiGroup: rbac.authorization.k8s.io
+

--- a/deploy/prometurbo/templates/serviceaccount.yaml
+++ b/deploy/prometurbo/templates/serviceaccount.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccountName }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.roleName }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.turbonomic.io
+    resources:
+      - prometheusquerymappings
+      - prometheusserverconfigs
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+---
+kind: ClusterRoleBinding
+# For OpenShift 3.4-3.7 use apiVersion: v1
+# For kubernetes 1.9 use rbac.authorization.k8s.io/v1
+# For kubernetes 1.8 use rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.roleBinding }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  # User creating this resource must have permissions to add this policy to the SA
+  kind: ClusterRole
+  # accepted values cluster-reader disc and monitoring.
+  name: {{ .Values.roleName }}
+  # For OpenShift v3.4 remove apiGroup line
+  apiGroup: rbac.authorization.k8s.io
+


### PR DESCRIPTION
Due to an error in .gitignore, the new `serviceaccount.yaml` file were not pushed. This PR addresses the issue.