### PR TITLE
[OM-99776]:Support multi-stage build and update GO to 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,12 @@ vet:
 
 clean:
 	@rm -rf ${OUTPUT_DIR}/linux ${bin}
+
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+REPO_NAME ?= icr.io/cpopen/turbonomic
+.PHONY: docker-buildx
+docker-buildx:
+	docker buildx create --name prometurbo-builder
+	- docker buildx use prometurbo-builder
+	- docker buildx build --platform=$(PLATFORMS) --push --tag $(REPO_NAME)/$(PROJECT):$(VERSION) -f build/Dockerfile.multi-archs --build-arg version=$(VERSION) .
+	docker buildx rm prometurbo-builder

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,0 +1,48 @@
+# Building base image
+FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
+ARG version
+ENV PROMETURBO_VERSION $version
+WORKDIR /workspace
+ADD . ./
+RUN make build
+
+FROM registry.access.redhat.com/ubi8-minimal
+MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
+ARG GIT_COMMIT
+ARG TARGETPLATFORM
+ENV GIT_COMMIT ${GIT_COMMIT}
+
+### Atomic/OpenShift Labels - https://github.com/projectatomic/ContainerApplicationGenericLabels
+LABEL name="Prometurbo Container" \
+      vendor="Turbonomic" \
+      version="v8.0.0" \
+      release="1" \
+      summary="Performance assurance for the applications in Openshift" \
+      description="Prometurbo Container leverages Turbonomic control platform, to assure the performance of micro-services running in OpenShift, as well as the efficiency of underlying infrastructure." \
+### Required labels above - recommended below
+      url="https://www.turbonomic.com" \
+      io.k8s.description="Prometurbo Container will monitor and control the entire stack, from OpenShift down to your underlying infrastructure. " \
+      io.k8s.display-name="Prometurbo Container" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="turbonomic, Multicloud Container"
+
+RUN microdnf update -y krb5-libs
+
+### add licenses to this directory
+COPY build/licenses /licenses
+
+COPY build/Dockerfile /Dockerfile
+
+### Setup user for build execution and application runtime
+ENV APP_ROOT=/opt/turbonomic
+ENV PATH=$PATH:${APP_ROOT}/bin
+
+RUN mkdir -p ${APP_ROOT}/bin
+COPY --from=builder /workspace/prometurbo ${APP_ROOT}/bin/prometurbo
+RUN chmod -R ug+x ${APP_ROOT}/bin && sync && \
+    chmod -R g=u ${APP_ROOT}
+
+####### Add app-specific needs below. #######
+USER 10001
+WORKDIR ${APP_ROOT}
+ENTRYPOINT ["/opt/turbonomic/bin/prometurbo"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbonomic/prometurbo
 
-go 1.19
+go 1.20 //Make sure you sync the change to the file Dockerfile.multi-archs after you update the version here
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
# Intent
Please refer to the PR: https://github.com/turbonomic/kubeturbo/pull/838

# Background
Please refer to the PR: https://github.com/turbonomic/kubeturbo/pull/838

# Implementation
Please refer to the PR: https://github.com/turbonomic/kubeturbo/pull/838

# Test

1. Run the command `make docker-buildx` to build multi-arch images and push it to docker(or icr)
Could see `prometurbo` image is built and pushed to docker with multi-archs
![image](https://user-images.githubusercontent.com/61252360/230468627-d3251716-e407-485e-895d-650b4d885de1.png)


3. Scan the image with `twistlock`
The report doesn't have any CVE issue on Go

[twistlock-scan-results-20230406-185150-N-UTC-EE766333.results.csv](https://github.com/turbonomic/prometurbo/files/11173678/twistlock-scan-results-20230406-185150-N-UTC-EE766333.results.csv)

5. Deploy the image in a K8s cluster and check if the pod can run 
The pod could run with the new image and there is  no outstanding error in the log