### PR TITLE
Fix the issue for supporting multi-platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,12 @@ clean:
 
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 REPO_NAME ?= icr.io/cpopen/turbonomic
+.PHONY: multi-archs
+multi-archs:
+	env GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o ${bin} ./cmd
 .PHONY: docker-buildx
 docker-buildx:
 	docker buildx create --name prometurbo-builder
 	- docker buildx use prometurbo-builder
-	- docker buildx build --platform=$(PLATFORMS) --push --tag $(REPO_NAME)/$(PROJECT):$(VERSION) -f build/Dockerfile.multi-archs --build-arg version=$(VERSION) .
+	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --push --tag $(REPO_NAME)/$(PROJECT):$(VERSION) -f build/Dockerfile.multi-archs --build-arg VERSION=$(VERSION) .
 	docker buildx rm prometurbo-builder

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,10 +1,10 @@
 # Building base image
 FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
-ARG version
-ENV PROMETURBO_VERSION $version
+ARG VERSION TARGETOS TARGETARCH
+ENV PROMETURBO_VERSION $VERSION
 WORKDIR /workspace
 ADD . ./
-RUN make build
+RUN make multi-archs
 
 FROM registry.access.redhat.com/ubi8-minimal
 MAINTAINER Turbonomic <turbodeploy@turbonomic.com>


### PR DESCRIPTION
# Intent
To fix the problem that the `prometurbo` binary in the ppc64le/arm64/s390x image is wrongly built

# Background
https://vmturbo.atlassian.net/browse/OM-100670

# Implementation
Pass the `GOOS` and GOARCH` arguments to the build command


# Test
```
root@dawning1:~# uname -a
Linux dawning1.fyre.ibm.com 5.4.0-144-generic #161-Ubuntu SMP Fri Feb 3 14:49:07 UTC 2023 ppc64le ppc64le ppc64le GNU/Linux
root@dawning1:~# docker pull kevin0204/prometurbo:8.8.6-LAST
8.8.6-LAST: Pulling from kevin0204/prometurbo
a3ece89037f7: Pull complete 
7968d67930b1: Pull complete 
d0c89ff1051f: Pull complete 
25faa6ffa235: Pull complete 
e0256f99bfab: Pull complete 
c0d62a0bfbb6: Pull complete 
d8719c7a336e: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:618aaec2a3371dc0a28565904ff34a9c5895c790662d0fd4493a8157355594eb
Status: Downloaded newer image for kevin0204/prometurbo:8.8.6-LAST
docker.io/kevin0204/prometurbo:8.8.6-LAST
root@dawning1:~# docker run -it --entrypoint sh  kevin0204/prometurbo:8.8.6-LAST
sh-4.4$ exec /opt/turbonomic/bin/prometurbo 
I0416 23:02:29.381889       1 prometurbo.go:80] Running prometurbo GIT_COMMIT: 
I0416 23:02:29.384116       1 provider.go:37] Metrics config file /etc/prometurbo/prometheus.config does not exist.
F0416 23:02:29.384140       1 prometurbo.go:122] Fatal error: failed to get in-cluster config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined.

```