### PR TITLE
[OM-100448] Use the entire cluster svc ID as the unique identifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ debug: clean
 	go build -ldflags $(LDFLAGS) -gcflags "-N -l" -o ${bin}.debug ./cmd
 
 docker: product
-	cd build; DOCKER_BUILDKIT=1 docker build -t turbonomic/prometurbo --build-arg $(GIT_COMMIT) .
+	cd build; DOCKER_BUILDKIT=1 docker build -t turbonomic/prometurbo --build-arg $(GIT_COMMIT) --load .
+
 
 test: clean
 	@go test -v -race ./pkg/...

--- a/pkg/provider/customresource/provider.go
+++ b/pkg/provider/customresource/provider.go
@@ -3,8 +3,6 @@ package customresource
 import (
 	"context"
 	"fmt"
-	"regexp"
-
 	"github.com/golang/glog"
 	"github.com/turbonomic/turbo-metrics/api/v1alpha1"
 	"k8s.io/api/core/v1"
@@ -118,12 +116,5 @@ func getKubernetesServiceID(kubeClient client.Client) (string, error) {
 		return "", fmt.Errorf("failed to get default kubernetes service %s/%s: %v",
 			defaultNamespace, defaultServiceName, err)
 	}
-	svcUID := string(svc.GetUID())
-	regex := regexp.MustCompile("^[0-9a-fA-F]{8}")
-	match := regex.FindStringSubmatch(svcUID)
-	if len(match) != 1 {
-		return "", fmt.Errorf("failed to parse UUID %v of the default kubernetes service %s/%s",
-			svcUID, defaultNamespace, defaultServiceName)
-	}
-	return match[0], nil
+	return string(svc.GetUID()), nil
 }

--- a/pkg/provider/task.go
+++ b/pkg/provider/task.go
@@ -111,6 +111,7 @@ func (t *Task) getMetricsForEntity() []*data.DIFEntity {
 
 func (t *Task) getEntityId(hostedOnVM bool, entityAttr *EntityAttribute) (entityId string) {
 	entityId = entityAttr.ID
+	// Use ID directly when app is hosted on VM
 	if hostedOnVM {
 		return
 	}

--- a/pkg/provider/task_test.go
+++ b/pkg/provider/task_test.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/turbonomic/turbo-metrics/api/v1alpha1"
+)
+
+var (
+	taskWithNoId           = &Task{}
+	taskWithClusterIdK8sId = &Task{
+		clusterId: &v1alpha1.ClusterIdentifier{
+			ClusterLabels: map[string]string{
+				"cluster": "clusterA",
+			},
+			ID: "5f2bd289",
+		},
+		k8sSvcId: "cda4d884-a053-4aba-8576-afa5d923e7c6",
+	}
+	taskWithK8sIdOnly = &Task{
+		k8sSvcId: "cda4d884-a053-4aba-8576-afa5d923e7c6",
+	}
+	entityAttr = &EntityAttribute{
+		ID: "10.254.15.158-demoapp",
+		IP: "10.254.15.158",
+	}
+)
+
+func TestGetMatchingAttributeWithClusterId(t *testing.T) {
+	matchingAttrForAppOnVM := taskWithClusterIdK8sId.getMatchingAttribute(true, entityAttr)
+	assert.Equal(t, "10.254.15.158", matchingAttrForAppOnVM)
+	matchingAttrForAppOnContainer := taskWithClusterIdK8sId.getMatchingAttribute(false, entityAttr)
+	assert.Equal(t, "10.254.15.158-5f2bd289", matchingAttrForAppOnContainer)
+}
+
+func TestGetMatchingAttributeWithK8sId(t *testing.T) {
+	matchingAttrForAppOnVM := taskWithK8sIdOnly.getMatchingAttribute(true, entityAttr)
+	assert.Equal(t, "10.254.15.158", matchingAttrForAppOnVM)
+	matchingAttrForAppOnContainer := taskWithK8sIdOnly.getMatchingAttribute(false, entityAttr)
+	assert.Equal(t, "10.254.15.158-cda4d884-a053-4aba-8576-afa5d923e7c6", matchingAttrForAppOnContainer)
+}
+
+func TestGetMatchingAttributeWithNoId(t *testing.T) {
+	matchingAttrForAppOnVM := taskWithNoId.getMatchingAttribute(true, entityAttr)
+	assert.Equal(t, "10.254.15.158", matchingAttrForAppOnVM)
+	matchingAttrForAppOnContainer := taskWithNoId.getMatchingAttribute(false, entityAttr)
+	assert.Equal(t, "10.254.15.158", matchingAttrForAppOnContainer)
+}
+
+func TestGetEntityIdWithClusterId(t *testing.T) {
+	entityIdForAppOnVM := taskWithClusterIdK8sId.getEntityId(true, entityAttr)
+	assert.Equal(t, "10.254.15.158-demoapp", entityIdForAppOnVM)
+	entityIdForAppOnContainer := taskWithClusterIdK8sId.getEntityId(false, entityAttr)
+	assert.Equal(t, "10.254.15.158-demoapp-5f2bd289", entityIdForAppOnContainer)
+}
+
+func TestGetEntityIdWithK8sId(t *testing.T) {
+	entityIdForAppOnVM := taskWithK8sIdOnly.getEntityId(true, entityAttr)
+	assert.Equal(t, "10.254.15.158-demoapp", entityIdForAppOnVM)
+	entityIdForAppOnContainer := taskWithK8sIdOnly.getEntityId(false, entityAttr)
+	assert.Equal(t, "10.254.15.158-demoapp-cda4d884-a053-4aba-8576-afa5d923e7c6", entityIdForAppOnContainer)
+}
+
+func TestGetEntityIdWithNoId(t *testing.T) {
+	entityIdForAppOnVM := taskWithNoId.getEntityId(true, entityAttr)
+	assert.Equal(t, "10.254.15.158-demoapp", entityIdForAppOnVM)
+	entityIdForAppOnContainer := taskWithNoId.getEntityId(false, entityAttr)
+	assert.Equal(t, "10.254.15.158-demoapp", entityIdForAppOnContainer)
+}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -85,8 +85,9 @@ func buildSvcByNamespace(entities []*data.DIFEntity) serviceByNamespace {
 		// Only create service entities from application and databaseServer
 		ServicePrefix := "Service-"
 		svcID := ServicePrefix + entity.UID
+		svcName := ServicePrefix + entity.Name
 		namespace := entity.GetNamespace()
-		svc := data.NewDIFEntity(svcID, "service").WithNamespace(namespace)
+		svc := data.NewDIFEntity(svcID, "service").WithName(svcName).WithNamespace(namespace)
 		for meType, meList := range entity.Metrics {
 			svc.AddMetrics(meType, meList)
 		}


### PR DESCRIPTION
Today we use `<IP>-<First Segment Of Cluster ID>` as the matching attribute of an entity. This is likely to be risky as there is still a possibility for collision. We have decided to use the `<IP>-<Full Cluster ID>` instead such that there the chance for collision will be practically zero.

As a part of the changes, we also make the entity ID unique by appending the cluster ID.

We only append Cluster ID to matching attribute and entity ID when the application is hosted on container.

I have decided not to hash the string because:
* The length of a typical MD5 or SHA256 hash range from 32 - 64 characters, which doesn't really save much space
* It becomes difficult to debug when there is a problem with stitching when the value is hashed

Sample output from `prometurbo` where `uniqueId` and `ipAddress` fields are appended with cluster svc id:

```json
    {
      "uniqueId": "Service-10.254.18.32-demoapp-cda4d884-a053-4aba-8576-afa5d923e7c6",
      "type": "service",
      "name": "Service-10.254.18.32-demoapp",
      "hostedOn": null,
      "matchIdentifiers": {
        "ipAddress": "Service-10.254.18.32-cda4d884-a053-4aba-8576-afa5d923e7c6"
      },
      "partOf": [
        {
          "entity": "businessApplication",
          "uniqueId": "Demoapp [FYRE-OCP411]-demoapp-http://prometheus.istio-system:9090"
        }
      ],
      "metrics": {
        "responseTime": [
          {
            "average": 6.544444443864954
          }
        ],
        "transaction": [
          {
            "average": 0.3333333333333333
          }
        ]
      }
    },
    {
      "uniqueId": "10.254.18.32-demoapp-cda4d884-a053-4aba-8576-afa5d923e7c6",
      "type": "application",
      "name": "10.254.18.32-demoapp",
      "hostedOn": null,
      "matchIdentifiers": {
        "ipAddress": "10.254.18.32-cda4d884-a053-4aba-8576-afa5d923e7c6"
      },
      "partOf": [
        {
          "entity": "service",
          "uniqueId": "Service-10.254.18.32-demoapp-cda4d884-a053-4aba-8576-afa5d923e7c6",
          "label": "twitter-cass-friend"
        }
      ],
      "metrics": {
        "responseTime": [
          {
            "average": 6.544444443864954
          }
        ],
        "transaction": [
          {
            "average": 0.3333333333333333
          }
        ]
      }
    },

```
