### PR TITLE
[TRB-40016]: Update prometurbo deployment with new registration related configuration

### DIFF
--- a/deploy/prometurbo-operator/config/crd/bases/charts.helm.k8s.io_prometurboes.yaml
+++ b/deploy/prometurbo-operator/config/crd/bases/charts.helm.k8s.io_prometurboes.yaml
@@ -119,6 +119,16 @@ spec:
                   opsManagerPassword:
                     description: Turbo admin user password
                     type: string
+              sdkProtocolConfig:
+                description: Configurations to register probe with Turbo Server
+                type: object
+                properties:
+                  registrationTimeoutSec:
+                    description: Time in seconds to wait for registration response from the Turbo Server
+                    type: integer
+                  restartOnRegistrationTimeout:
+                    description: Restart probe container on registration timeout
+                    type: boolean
               targetName:
                 description: Optional target name for registration
                 type: string

--- a/deploy/prometurbo-operator/config/samples/charts_v1_prometurbo.yaml
+++ b/deploy/prometurbo-operator/config/samples/charts_v1_prometurbo.yaml
@@ -28,6 +28,11 @@ spec:
     #opsManagerUserName: Turbo_username
     #opsManagerPassword: Turbo_password
 
+  # Configurations to register probe with Turbo Server
+  sdkProtocolConfig:
+    registrationTimeoutSec: 300
+    restartOnRegistrationTimeout: false
+
   # Specify a unique target name, defaults to Prometheus
   #targetName: Prometheus
 

--- a/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_prometurbos_crd.yaml
+++ b/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_prometurbos_crd.yaml
@@ -128,6 +128,16 @@ spec:
                   opsManagerPassword:
                     description: Turbo admin user password
                     type: string
+              sdkProtocolConfig:
+                description: Configurations to register probe with Turbo Server
+                type: object
+                properties:
+                  registrationTimeoutSec:
+                    description: Time in seconds to wait for registration response from the Turbo Server
+                    type: integer
+                  restartOnRegistrationTimeout:
+                    description: Restart probe container on registration timeout
+                    type: boolean
               targetName:
                 description: Optional target name for registration
                 type: string

--- a/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1_prometurbo_cr.yaml
+++ b/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1_prometurbo_cr.yaml
@@ -14,6 +14,12 @@ spec:
     #opsManagerUserName: Turbo_username
     #opsManagerPassword: Turbo_password
 
+  # Configurations to register probe with Turbo Server
+  #sdkProtocolConfig:
+    #  registrationTimeoutSec: 300
+    #  restartOnRegistrationTimeout: false
+
+
   # Specify a unique target name, defaults to Prometheus
   #targetName: Prometheus
 

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-turbodif.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/configmap-turbodif.yaml
@@ -13,6 +13,10 @@ data:
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
+        },
+         "sdkProtocolConfig": {
+            "registrationTimeoutSec": {{ .Values.sdkProtocolConfig.registrationTimeoutSec }},
+            "restartOnRegistrationTimeout": {{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}
         }
       {{- if and .Values.targetName .Values.targetAddress }}
       },

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -36,6 +36,11 @@ restAPIConfig:
   opsManagerUserName: Turbo_username
   opsManagerPassword: Turbo_password
 
+# Turbo server registration process configuration
+sdkProtocolConfig:
+  registrationTimeoutSec: 300
+  restartOnRegistrationTimeout: false
+
 # Specify a unique target name
 targetName: Prometheus
 # Specify metric endpoint from Prometurbo

--- a/deploy/prometurbo/templates/configmap-turbodif.yaml
+++ b/deploy/prometurbo/templates/configmap-turbodif.yaml
@@ -13,6 +13,10 @@ data:
         "restAPIConfig": {
           "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",
           "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
+        },
+        "sdkProtocolConfig": {
+           "registrationTimeoutSec": {{ .Values.sdkProtocolConfig.registrationTimeoutSec }},
+           "restartOnRegistrationTimeout": {{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}
         }
       {{- if and .Values.targetName .Values.targetAddress }}
       },

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -36,6 +36,10 @@ restAPIConfig:
   opsManagerUserName: Turbo_username
   opsManagerPassword: Turbo_password
 
+sdkProtocolConfig:
+  registrationTimeoutSec: 300
+  restartOnRegistrationTimeout: false
+
 # Specify a unique target name
 targetName: Prometheus
 # Specify metric endpoint from Prometurbo


### PR DESCRIPTION

[PR](https://github.com/turbonomic/data-ingestion-framework/pull/58) and #https://github.com/turbonomic/turbo-go-sdk/pull/147 added new configuration options to probes during registration with server.
This PR exposes these options to the users during deployment with operators and helm charts.

- Updated the Prometurbo operator CRD

- Updated the default values provided in the Helm charts

```
# Turbo server registration process configuration
sdkProtocolConfig:
  registrationTimeoutSec: 300
  restartOnRegistrationTimeout: false
```

- Updated the configmap template in the Helm Charts

```
{
      "communicationConfig": {
        "serverMeta": {
        {{- if .Values.serverMeta.proxy }}
          "proxy": "{{ .Values.serverMeta.proxy }}",
        {{- end }}
          "version": "{{ .Values.serverMeta.version }}",
          "turboServer": "{{ .Values.serverMeta.turboServer }}"
        },
        "restAPIConfig": {
          "opsManagerUserName": "{{ .Values.restAPIConfig.opsManagerUserName }}",
          "opsManagerPassword": "{{ .Values.restAPIConfig.opsManagerPassword }}"
        },
        "sdkProtocolConfig": {
           "registrationTimeoutSec": {{ .Values.sdkProtocolConfig.registrationTimeoutSec }},
           "restartOnRegistrationTimeout": {{ .Values.sdkProtocolConfig.restartOnRegistrationTimeout }}
        }
      },
```
Changes made in the `deploy/prometurbo-operatoras` well as `deploy/prometurbo`

### Testing

- Built a DIF probe image  and push 
`docker buildx build -f build/Dockerfile --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --label “8.9” --push -t pallavidebnath/turbodif-probe-sdk-config .`

- Changed prometurbo helm-charts` values.yaml `to use the new turbodif image (`pallavidebnath/turbodif-probe-sdk-config` )

- Build Prometurbo operator image using the DockerFile from the prometuro-operator directory
`docker buildx build -f build/Dockerfile --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --label “8.9” --push -t pallavidebnath/prometurbo-operator-sdk-config .`

- Copied the prometurbo operator yamls to Frye VM `9.46.99.154`
- Edited prometurbo’s operator.yaml to use this image `pallavidebnath/prometurbo-operator-sdk-config`
- Used namespace pdn for creating deployments.
- Deploy the operator's service account, role binding in namespace `pdn`
- Deploy the operator.yaml, check that the prometurbo operator pod comes up. 
- Check the logs if the operator is able to run successfully

IN PROGRESS, will update with results
