### PR TITLE
[TRB-40866]:Update Go version to 1.20.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 go:
-  - 1.19.4
+  - 1.20.4
 
 go_import_path: github.com/turbonomic/prometurbo
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,5 +1,5 @@
 # Building base image
-FROM --platform=$BUILDPLATFORM golang:1.20.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20.4 AS builder
 ARG VERSION TARGETOS TARGETARCH
 ENV PROMETURBO_VERSION $VERSION
 WORKDIR /workspace


### PR DESCRIPTION
# Intent
To solve the issue of  CVE-2023-24540
https://jsw.ibm.com/browse/TRB-40866

# Test
Please refer to the `twistlock` scan result

[twistlock-scan-results-20230602-154127-N-UTC-844EE888.results.csv](https://github.com/turbonomic/prometurbo/files/11636830/twistlock-scan-results-20230602-154127-N-UTC-844EE888.results.csv)

