### PR TITLE
[TRB-40754]: Unique ClusterRoleBinding name

### DIFF
--- a/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1_prometurbo_cr.yaml
+++ b/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1_prometurbo_cr.yaml
@@ -29,13 +29,13 @@ spec:
     #  registrationTimeoutSec: 300
     #  restartOnRegistrationTimeout: false
 
-  # Specify a unique target name, defaults to Prometheus
+  # Specify a UNIQUE target name
   targetName: Cluster_name
 
-  # Specify a unique target type suffix, defaults to Prometheus
+  # Specify a UNIQUE target type suffix, defaults to Prometheus
   # The Target Type will appear as DataIngestionFramework-<targetTypeSuffix> on the UI
   # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
-  #targetTypeSuffix: Prometheus
+  targetTypeSuffix: Cluster_name
 
   # Command line arguments
   args:

--- a/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1_prometurbo_cr.yaml
+++ b/deploy/prometurbo-operator/deploy/crds/charts.helm.k8s.io_v1_prometurbo_cr.yaml
@@ -30,7 +30,7 @@ spec:
     #  restartOnRegistrationTimeout: false
 
   # Specify a unique target name, defaults to Prometheus
-  #targetName: Prometheus
+  targetName: Cluster_name
 
   # Specify a unique target type suffix, defaults to Prometheus
   # The Target Type will appear as DataIngestionFramework-<targetTypeSuffix> on the UI

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/serviceaccount.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.serviceAccountName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,7 +34,7 @@ kind: ClusterRoleBinding
 # For kubernetes 1.8 use rbac.authorization.k8s.io/v1beta1
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.roleBinding }}
+  name: {{ .Values.roleBinding }}-{{ .Release.Name }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.serviceAccountName }}
@@ -43,7 +43,7 @@ roleRef:
   # User creating this resource must have permissions to add this policy to the SA
   kind: ClusterRole
   # accepted values cluster-reader disc and monitoring.
-  name: {{ .Values.roleName }}
+  name: {{ .Values.roleName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
   # For OpenShift v3.4 remove apiGroup line
   apiGroup: rbac.authorization.k8s.io
 

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -41,15 +41,15 @@ sdkProtocolConfig:
   registrationTimeoutSec: 300
   restartOnRegistrationTimeout: false
 
-# Specify a unique target name
-targetName: Prometheus
+# Specify a UNIQUE target name
+targetName: Cluster_name
 # Specify metric endpoint from Prometurbo
 targetAddress: http://127.0.0.1:8081/metrics
 
-# Specify a unique suffix to the DataIngestionFramework target type
+# Specify a UNIQUE suffix to the DataIngestionFramework target type
 # The Target Type will appear as DataIngestionFramework-<targetTypeSuffix> on the UI
 # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
-targetTypeSuffix: Prometheus
+targetTypeSuffix: Cluster_name
 
 args:
   # logging level

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/values.yaml
@@ -41,15 +41,15 @@ sdkProtocolConfig:
   registrationTimeoutSec: 300
   restartOnRegistrationTimeout: false
 
-# Specify a UNIQUE target name
-targetName: Cluster_name
+# Specify a unique target name
+targetName: Prometheus
 # Specify metric endpoint from Prometurbo
 targetAddress: http://127.0.0.1:8081/metrics
 
-# Specify a UNIQUE suffix to the DataIngestionFramework target type
+# Specify a unique suffix to the DataIngestionFramework target type
 # The Target Type will appear as DataIngestionFramework-<targetTypeSuffix> on the UI
 # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
-targetTypeSuffix: Cluster_name
+targetTypeSuffix: Prometheus
 
 args:
   # logging level

--- a/deploy/prometurbo/templates/serviceaccount.yaml
+++ b/deploy/prometurbo/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.roleName }}
+  name: {{ .Values.roleName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""
@@ -37,13 +37,13 @@ metadata:
   name: {{ .Values.roleBinding }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.serviceAccountName }}
+    name: {{ .Values.serviceAccountName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   # User creating this resource must have permissions to add this policy to the SA
   kind: ClusterRole
   # accepted values cluster-reader disc and monitoring.
-  name: {{ .Values.roleName }}
+  name: {{ .Values.roleName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
   # For OpenShift v3.4 remove apiGroup line
   apiGroup: rbac.authorization.k8s.io
 

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -40,15 +40,15 @@ sdkProtocolConfig:
   registrationTimeoutSec: 300
   restartOnRegistrationTimeout: false
 
-# Specify a unique target name
+# Specify a UNIQUE target name
 targetName: Cluster_name
 # Specify metric endpoint from Prometurbo
 targetAddress: http://127.0.0.1:8081/metrics
 
-# Specify a unique suffix to the DataIngestionFramework target type
+# Specify a UNIQUE suffix to the DataIngestionFramework target type
 # The Target Type will appear as DataIngestionFramework-<targetTypeSuffix> on the UI
 # Do not specify Turbonomic as the targetTypeSuffix, it is reserved for internal use
-targetTypeSuffix: Prometheus
+targetTypeSuffix: Cluster_name
 
 args:
   # logging level

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -41,7 +41,7 @@ sdkProtocolConfig:
   restartOnRegistrationTimeout: false
 
 # Specify a unique target name
-targetName: Prometheus
+targetName: Cluster_name
 # Specify metric endpoint from Prometurbo
 targetAddress: http://127.0.0.1:8081/metrics
 


### PR DESCRIPTION
**Intent**

We want to setup multiple Prometurbo probes for the same k8s cluster.

**Problem** 

When creating the second Prometurbo probe, we get the error that ClusterRoleBinding already exists.

**Solution**

Make ClusterRoleBinding unique based on the Prometurbo name and the namespace.

In addition, Eva insisted that we should not use the default targetName when creating Prometurbo instance.

**Testing**

Tested for two type of Prometurbo deployments:

- via Helm Charts
- via Operator

For each method, I created two Prometurbos. I saw no errors in Prometurbo Operator log.