### PR TITLE
[TRB-40754]: Unique ClusterRoleBinding name 2

### DIFF
--- a/deploy/prometurbo-operator/deploy/operator.yaml
+++ b/deploy/prometurbo-operator/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: prometurbo-operator
-        image: icr.io/cpopen/prometurbo-operator:8.8.3
+        image: icr.io/cpopen/prometurbo-operator:8.9.1
         imagePullPolicy: Always
         env:
         - name: WATCH_NAMESPACE

--- a/deploy/prometurbo-operator/helm-charts/prometurbo/templates/serviceaccount.yaml
+++ b/deploy/prometurbo-operator/helm-charts/prometurbo/templates/serviceaccount.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
+  name: {{ .Values.serviceAccountName }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.roleName }}
+  name: {{ .Values.roleName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
 rules:
   - apiGroups:
       - ""

--- a/deploy/prometurbo/templates/serviceaccount.yaml
+++ b/deploy/prometurbo/templates/serviceaccount.yaml
@@ -34,10 +34,10 @@ kind: ClusterRoleBinding
 # For kubernetes 1.8 use rbac.authorization.k8s.io/v1beta1
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.roleBinding }}
+  name: {{ .Values.roleBinding }}-{{ .Release.Name }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.serviceAccountName }}-{{ .Release.Name }}-{{ .Release.Namespace }}
+    name: {{ .Values.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   # User creating this resource must have permissions to add this policy to the SA

--- a/deploy/prometurbo/values.yaml
+++ b/deploy/prometurbo/values.yaml
@@ -7,9 +7,9 @@ replicaCount: 1
 # Replace the image with desired version:8.7.5 or snapshot version:8.7.5-SNAPSHOT from icr.io
 image:
   prometurboRepository: icr.io/cpopen/turbonomic/prometurbo
-  prometurboTag: 8.7.5
+  prometurboTag: 8.9.1
   turbodifRepository: icr.io/cpopen/turbonomic/turbodif
-  turbodifTag: 8.7.5
+  turbodifTag: 8.9.1
   pullPolicy: IfNotPresent
 
 # Specify the name of the serviceaccount


### PR DESCRIPTION
**Intent**

We want to run multiple Prometurbos on the same cluster.

**Fix**

ClusteRole and ClusterRoleBinding are cluster-wide resources. Their names need to be unique. ServiceAccount is namespaced and does not need to be unique.