### PR TITLE
[TRB-42880]: Upgrade go version to 1.20.5 to fix cve-2023-29404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 go:
-  - 1.20.4
+  - 1.20.5
 
 go_import_path: github.com/turbonomic/prometurbo
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,5 +1,5 @@
 # Building base image
-FROM --platform=$BUILDPLATFORM golang:1.20.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20.5 AS builder
 ARG VERSION TARGETOS TARGETARCH
 ENV PROMETURBO_VERSION $VERSION
 WORKDIR /workspace


### PR DESCRIPTION
# Intent
- Upgrade go version to 1.20.5 to solve the [CVE issue](https://jsw.ibm.com/browse/TRB-42881)

# Testing

Build dev image with the changes and scan it with twistlock, vulnerability issue resolved
`./tt images pull-and-scan --user xxxxx --url "https://w3twistlock.sos.ibm.com" --control-group public docker.io/sumanthkodali/turbodif-cve:latest`


[twistlock-scan-results-20230703-184344-N-UTC-E53B3D54.results.csv](https://github.com/turbonomic/prometurbo/files/11940189/twistlock-scan-results-20230703-184344-N-UTC-E53B3D54.results.csv)

