### PR TITLE
TRB 44355 automation test for dynamic logging

### DIFF
--- a/deploy/prometurbo-operator/Makefile
+++ b/deploy/prometurbo-operator/Makefile
@@ -320,4 +320,4 @@ docker-buildx:
 
 .PHONY: test
 test:
-	bash ./test.sh
+	OPERATOR_IMAGE_VERSION=${VERSION} PROMETURBO_IMAGE_VERSION=${VERSION} bash ./test.sh

--- a/deploy/prometurbo-operator/Makefile
+++ b/deploy/prometurbo-operator/Makefile
@@ -317,3 +317,7 @@ docker-buildx:
 	- docker buildx use prometurbo-operator-builder
 	- docker buildx build --platform=$(PLATFORMS) --label "git-commit=$(GIT_COMMIT)" --label "git-version=$(VERSION)" --provenance=false --push --tag $(REPO_NAME)/prometurbo-operator:$(VERSION) --build-arg VERSION=$(VERSION) .
 	docker buildx rm prometurbo-operator-builder
+
+.PHONY: test
+test:
+	bash ./test.sh

--- a/deploy/prometurbo-operator/test.sh
+++ b/deploy/prometurbo-operator/test.sh
@@ -1,0 +1,336 @@
+#!/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname $0)" && pwd)"
+ERR_LOG=$(mktemp --suffix _prome.errlog)
+WAIT_FOR_DEPLOYMENT=30
+OPERATOR_IMAGE_VERSION="8.9.5-SNAPSHOT"
+OPERATOR_IMAGE="icr.io\/cpopen\/prometurbo-operator:${OPERATOR_IMAGE_VERSION}"
+PROMETURBO_IMAGE_VERSION="8.9.5-SNAPSHOT"
+PROMETURBO_IMAGE_REPO="icr.io/cpopen/turbonomic/prometurbo"
+KUBECTL=kubectl
+# username and password for the local ops-manager
+OPS_MANAGER_USERNAME=administrator
+OPS_MANAGER_PASSWORD=administrator
+# container used to search for logs
+CONTAINER_NAME=prometurbo
+
+# turbonomic is the default namespace that matches the xl setup
+# please change the value according to your set up
+export namespace=turbonomic
+
+function rediscover_target {
+	DISPLAY_NAME=$1
+    ip=$($KUBECTL get services --no-headers -n $namespace | grep nginx | awk '{print $4; exit}' | cut -d "," -f 1)
+    cookie=$(curl -k -s -v "https://$ip/vmturbo/rest/login" --data "username=$OPS_MANAGER_USERNAME&password=$OPS_MANAGER_PASSWORD" 2>&1 | grep JSESSION | awk -F'=' '{print $2}' | awk -F';' '{print $1}')
+	response=$(curl -k -s --cookie "JSESSIONID=$cookie"-X GET "https://$ip/vmturbo/rest/targets?q=Prometheus&target_category=Custom&order_by=validation_status&ascending=true&query_method=regex" -H "accept: application/json")
+	target_uuid=$(echo "$response" | jq '. | .[] | "\(.uuid)"' | tr -d '"')
+	# rediscover
+	curl -k -s --cookie "JSESSIONID=$cookie"-X POST "https://${ip}/vmturbo/rest/targets/${target_uuid}?rediscover=true" -H "accept: application/json" -d '' # > /dev/null
+}
+
+function install_operator {
+	NS=$1
+	[ -z "${NS}" ] && echo -e "Operator namespace not provided" | tee -a ${ERR_LOG} && exit 1
+	$KUBECTL create ns ${NS}
+	# $KUBECTL delete -f ${SCRIPT_DIR}/deploy/crds/*crd.yaml
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/crds/*crd.yaml
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/service_account.yaml -n ${NS}
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/role_binding.yaml
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/prometurbo-operator-cluster-role.yaml
+	sed "s/image:.*/image: ${OPERATOR_IMAGE}/g" ${SCRIPT_DIR}/deploy/operator.yaml > ${SCRIPT_DIR}/deploy/updated_operator.yaml
+	$KUBECTL apply -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
+}
+
+function uninstall_operator {
+	NS=$1
+	[ -z "${NS}" ] && echo -e "Operator namespace not provided" | tee -a ${ERR_LOG} && exit 1
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/updated_operator.yaml -n ${NS}
+	rm ${SCRIPT_DIR}/deploy/updated_operator.yaml
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/role_binding.yaml
+	$KUBECTL delete -f ${SCRIPT_DIR}/deploy/service_account.yaml -n ${NS}
+	$KUBECTL delete ns ${NS}
+}
+
+function create_cr {
+	CR_SURFIX=$1
+	CLUSTER_ROLE=${2-"cluster-admin"}
+
+	# if we have .turbocreds pull the credentials from it instead
+	FILE="~/.turbocreds"
+	if [ -f "${FILE}" ]; then
+		if [[ $(grep -c "opsman_username" ${FILE}) -eq 1 ]]; then
+			OPS_MANAGER_USERNAME=`grep "opsman_username" ${FILE} | cut -d'=' -f2`
+			OPS_MANAGER_PASSWORD=`grep "opsman_password" ${FILE} | cut -d'=' -f2`
+		fi
+	fi
+
+	command -v xl_version &> /dev/null
+	[ $? -gt 0 ] && echo -e "Failed to invoke xl_version from environemnt" | tee -a ${ERR_LOG} && exit 1
+	XL_VERSION_DETAIL=$(xl_version)
+
+	# generated testing cr file based on the given input
+	HOST_IP=$(echo -e "${XL_VERSION_DETAIL}" | grep "Server:" | awk '{print $2}')
+	[ -z "${HOST_IP}" ] && echo -e "Failed to get exposed XL IP" | tee -a ${ERR_LOG} && exit 1
+
+	XL_VERSION=$(echo -e "${XL_VERSION_DETAIL}" | grep "Version:" | awk '{print $2}')
+	[ -z "${XL_VERSION}" ] && echo -e "Failed to get exposed XL version" | tee -a ${ERR_LOG} && exit 1
+
+	CR_FILEPATH=$(mktemp --suffix _prometurbo_cr_${CR_SURFIX}.yaml)
+	echo ${CR_FILEPATH}
+
+	cat > ${CR_FILEPATH} <<- EOT
+	apiVersion: charts.helm.k8s.io/v1
+	kind: Prometurbo
+	metadata:
+	  name: prometurbo-${CR_SURFIX}
+	spec:
+	  serverMeta:
+	    version: ${XL_VERSION}
+	    turboServer: https://${HOST_IP}
+	  restAPIConfig:
+	    turbonomicCredentialsSecretName: "turbonomic-credentials"
+	    opsManagerUserName: ${OPS_MANAGER_USERNAME}
+	    opsManagerPassword: ${OPS_MANAGER_PASSWORD}
+	  targetConfig:
+	    targetName: ${CR_SURFIX}
+	  roleName: ${CLUSTER_ROLE}
+	  image:
+	    prometurboRepository: ${PROMETURBO_IMAGE_REPO}
+	    prometurboTag: ${PROMETURBO_IMAGE_VERSION}
+	    turbodifTag: ${PROMETURBO_IMAGE_VERSION}
+	    pullPolicy: Always
+	EOT
+}
+
+function install_cr {
+	# install cr in a given namespace and run checks
+	NS=$1
+	CR_FILE=$2
+	TEST_DESC=${3-"Install Prometurbo CR in ${NS}"}
+
+	[ -z "${NS}" ] && echo "Namespace not provided" | tee -a ${ERR_LOG} && return
+	[ ! -f "${CR_FILE}" ] && echo "CR file ${CR_FILE} not provided" | tee -a ${ERR_LOG} && return
+
+	echo -e "> Start testing for ${TEST_DESC}"
+	$KUBECTL create ns ${NS}
+	$KUBECTL apply -f ${CR_FILE} -n ${NS} && echo -e "Wait for ${WAIT_FOR_DEPLOYMENT}s to finish container creation"
+	sleep ${WAIT_FOR_DEPLOYMENT}
+
+	# rediscover target in case initial discovery doesn't show up
+	rediscover_target $TARGET_NAME	&& echo -e "Wait for 10s to finish rediscovering"
+	sleep 10
+
+	# check if the prometurbo deployment get generated
+	FAILED=0
+	# assumes there is only one deployment in the ns aside from operator deployment
+	CR_DEPLOY=$($KUBECTL get deploy -n ${NS} -o NAME | grep -v operator)
+	if [ -z "${CR_DEPLOY}" ]; then
+		echo -e "> ${TEST_DESC}........FAILED" | tee -a ${ERR_LOG}
+		return
+	elif [ -z "$($KUBECTL rollout status ${CR_DEPLOY} -n ${NS} | grep successfully)" ]; then
+		FAILED=$((${FAILED}+1))
+		echo -e ">  Deployment ${CR_DEPLOY} cr check........FAILED" | tee -a ${ERR_LOG}
+	else
+		echo -e ">  Deployment ${CR_DEPLOY} cr check........PASSED"
+	fi
+
+	# check if the cluster log is healthy
+	if [[ -z "$($KUBECTL logs ${CR_DEPLOY} -c ${CONTAINER_NAME} -n ${NS} | grep "Discovered .* entities")" ]]; then
+		FAILED=$((${FAILED}+1))
+		echo -e ">  Deployment ${CR_DEPLOY} log check........FAILED" | tee -a ${ERR_LOG}
+	else
+		echo -e ">  Deployment ${CR_DEPLOY} log check........PASSED"
+	fi
+
+	CR_DEPLOY_NAME=$($KUBECTL get ${CR_DEPLOY} -n ${NS} -o jsonpath={.metadata.name})
+
+	# check if the correct cluster role binding get generated
+	TARGET_ROLEBINDING="prometurbo-binding-${CR_DEPLOY_NAME}-${NS}"
+	$KUBECTL get ClusterRoleBinding "${TARGET_ROLEBINDING}" >/dev/null
+	if [ $? -gt 0 ]; then
+		FAILED=$((${FAILED}+1))
+		echo -e ">  ClusterRoleBinding ${TARGET_ROLEBINDING} check........FAILED" | tee -a ${ERR_LOG}
+	else
+		echo -e ">  ClusterRoleBinding ${TARGET_ROLEBINDING} check........PASSED"
+	fi
+
+	TARGET_ROLENAME=$(grep roleName ${CR_FILE} | awk '{print $2}')
+	if [ -z "${TARGET_ROLENAME}" ]; then
+		TARGET_ROLENAME="cluster-admin"
+	elif [ "${TARGET_ROLENAME}" != "cluster-admin" ]; then
+		TARGET_ROLENAME="${TARGET_ROLENAME}-${CR_DEPLOY_NAME}-${NS}"
+	fi
+	$KUBECTL get ClusterRole "${TARGET_ROLENAME}" >/dev/null
+	if [ $? -gt 0 ]; then
+		FAILED=$((${FAILED}+1))
+		echo -e ">  ClusterRole ${TARGET_ROLENAME} check........FAILED" | tee -a ${ERR_LOG}
+	else
+		echo -e ">  ClusterRole ${TARGET_ROLENAME} check........PASSED"
+	fi
+
+	# summarize the deployment test
+	if [ ${FAILED} -gt 0 ]; then
+		echo -e "> ${TEST_DESC}........FAILED" | tee -a ${ERR_LOG}
+	else
+		echo -e "> ${TEST_DESC}........PASSED"
+	fi
+}
+
+function uninstall_cr {
+	# unstall cr in a given namespace
+	NS=$1
+	CR_FILE=$2
+
+	if [ -f "${CR_FILE}" ] && [ -n "${NS}" ]; then
+		$KUBECTL delete -f ${CR_FILE} -n ${NS}
+	fi
+
+	[ -f "${CR_FILE}" ] && rm ${CR_FILE}
+	[ -n "${NS}" ] && $KUBECTL delete ns ${NS}
+}
+
+function update_cr_for_logging {
+	CR_NS1=$1
+	CR_FILE1=$2
+	LOGGING_LEVEL=$3
+	echo -e "Updating CR to add logging level..."
+	# existing method: adding spec.args.logginglevel causes pod to restart
+	# sed -i -e "$ a\  args:" $CR_FILE1
+	# sed -i -e "$ a\    logginglevel: 4" $CR_FILE1
+	# new method: adding spec.logging.level should not cause a restart
+	sed -i -e '$ a\  logging:' $CR_FILE1
+	sed -i -e "$ a\    level: $LOGGING_LEVEL" $CR_FILE1	
+	$KUBECTL apply -f ${CR_FILE} -n ${NS}
+}
+
+function wait_for_logging_update {
+	NAMESPACE=$1
+	POD_NAME=$2
+	MSG=""
+	declare -i COUNT=0
+
+	while [ -z "$MSG" ]
+	do 
+		echo "Wait for 10s for log level changes to be reflected..."
+		sleep 10
+		MSG=$($KUBECTL -n ${NAMESPACE} logs ${POD_NAME} -c ${CONTAINER_NAME} | grep "Logging level is changed from")
+		if [ $COUNT -eq 10 ]; then
+			echo "Timed out waiting for log level changes..." | tee -a ${ERR_LOG} && return
+		fi
+		COUNT+=1
+	done
+	echo $MSG
+}
+
+function test_prometurbo_setup {
+	echo -e "> Tearing up prometurbo tests"
+
+	# turbo is the default namespace that matches the one using in
+	# deploy/role_binding.yaml, please change the value accordingly
+	OPERATOR_NS=turbo
+	install_operator ${OPERATOR_NS}
+
+	CR_NS1=testns1
+	CR_NS2=testns2
+	CR_NS3=testns3
+	CR_NS4=testns4
+	CR_FILE1=$(create_cr testcr1)
+	CR_FILE2=$(create_cr testcr2)
+	CR_FILE3=$(create_cr testcr3 "turbo-cluster-reader")
+	CR_FILE4=$(create_cr testcr4 "turbo-cluster-reader")
+	install_cr ${CR_NS1} ${CR_FILE1} "Deploy single prometurbo test"
+	install_cr ${CR_NS2} ${CR_FILE2} "Deploy multiple prometurbos test"
+	install_cr ${CR_NS3} ${CR_FILE3} "Deploy single turbo-cluster-reader prometurbo test"
+	install_cr ${CR_NS4} ${CR_FILE4} "Deploy multiple turbo-cluster-reader prometurbos test"
+
+	echo -e "> Tearing down prometurbo tests"
+	uninstall_cr ${CR_NS1} ${CR_FILE1}
+	uninstall_cr ${CR_NS2} ${CR_FILE2}
+	uninstall_cr ${CR_NS3} ${CR_FILE3}
+	uninstall_cr ${CR_NS4} ${CR_FILE4}
+	uninstall_operator ${OPERATOR_NS}
+
+	TEST_RESULT=$(cat ${ERR_LOG})
+	if [ -n "${TEST_RESULT}" ]; then
+		echo -e "Prometurbo test failed see logs at: ${ERR_LOG}" && exit 1
+	else
+		echo "Test passed!"
+	fi
+
+	rm ${ERR_LOG}
+}
+
+
+function test_dynamic_logging {
+	echo -e "> Running dynamic logging tests"
+	NEW_LOGGING_LEVEL=4
+	NEW_LOGLEVEL_MSG="Begin to handle path" # example level 4 msg
+	OPERATOR_NS=turbo
+	install_operator ${OPERATOR_NS}
+	CR_NS1=testns1
+	CR_LABEL=testcr1
+	CR_FILE1=$(create_cr ${CR_LABEL})
+	install_cr ${CR_NS1} ${CR_FILE1} "Deploy prometurbo for dynamic logging"
+	POD_NAME=$($KUBECTL get pod -n ${NS} | grep ${CR_LABEL} | awk '{print $1}')
+	NUM_RESTART_BEFORE=$($KUBECTL get pod -n ${NS} ${POD_NAME} | awk 'FNR == 2 {print $4}')
+	HEAD_LOGS_BEFORE=$($KUBECTL -n ${NS} logs ${POD_NAME} -c ${CONTAINER_NAME} | head -n 2)
+
+	# DEBUGGING ONLY
+	echo "-------------Pod log before-----------------------------------------"
+	$KUBECTL -n ${NS} logs ${POD_NAME} -c ${CONTAINER_NAME}
+	echo "-------------End Pod log before-----------------------------------------"
+	update_cr_for_logging ${CR_NS1} ${CR_FILE1} ${NEW_LOGGING_LEVEL}
+
+	# wait until log level changes msg shows up
+	wait_for_logging_update ${NS} ${POD_NAME}
+
+	#rediscover prometurbo to generate new logs
+	TARGET_NAME=Prometheus-${CR_LABEL} 
+	rediscover_target $TARGET_NAME	&& echo -e "Wait for 10s to finish rediscovering"
+	sleep 10
+
+	# check to make sure new logging level is updated in the configmap
+	# expecting something like this in the configmap "{\n \"logging\": {\n \"level\": 5\n }\n}"
+	LOGLEVEL_CM=$($KUBECTL get cm prometurbo-config-prometurbo-${CR_LABEL} -n ${CR_NS1} -o json | jq '.data."turbo-autoreload.config"')
+	SEARCH_STR='level\\": '$NEW_LOGGING_LEVEL
+	[[ -z $(echo $LOGLEVEL_CM | grep "$SEARCH_STR") ]] && echo "Error: incorrect turbo-autoreload.config $LOGLEVEL_CM" | tee -a ${ERR_LOG}	
+
+	# check to make sure pod still exists
+	[[ $($KUBECTL get pod -n ${NS} ${POD_NAME} | grep "not found") ]] && echo "Error: pod not found after update" | tee -a ${ERR_LOG}	
+	
+	NUM_RESTART_AFTER=$($KUBECTL get pod -n ${NS} ${POD_NAME} | awk 'FNR == 2 {print $4}')
+	HEAD_LOGS_AFTER=$($KUBECTL -n ${NS} logs ${POD_NAME} -c ${CONTAINER_NAME} | head -n 2)
+	# check the pod restart number before and after cr update
+	[[ $NUM_RESTART_BEFORE != $NUM_RESTART_AFTER ]] && echo "Pod restarted after updating logging level" | tee -a ${ERR_LOG}	
+	# check if previous logs are preserved
+	[[ $HEAD_LOGS_BEFORE != $HEAD_LOGS_AFTER ]] && echo "Logs before CR update was erased\n$HEAD_LOGS_BEFORE\n$HEAD_LOGS_AFTER" | tee -a ${ERR_LOG}
+	# check if new logs contains message that should only show up in the new logging level
+	[[ -z $($KUBECTL -n ${NS} logs ${POD_NAME} -c ${CONTAINER_NAME} | grep "$NEW_LOGLEVEL_MSG") ]] && echo "Error: expected new log not found" | tee -a ${ERR_LOG}	
+
+	# DEBUGGING ONLY
+	echo "-------------Pod log after-----------------------------------------"
+	$KUBECTL -n ${NS} logs ${POD_NAME} -c ${CONTAINER_NAME}
+	echo "-------------End Pod log after-----------------------------------------"
+
+	echo -e "Cleanup..."
+	uninstall_cr ${CR_NS1} ${CR_FILE1}
+	uninstall_operator ${OPERATOR_NS}
+
+	TEST_RESULT=$(cat ${ERR_LOG})
+	if [ -n "${TEST_RESULT}" ]; then
+		echo -e "Dynamic logging test failed see logs at: ${ERR_LOG}" && exit 1
+	else
+		echo "Test passed!"
+	fi
+}
+
+function main {	
+	# test_prometurbo_setup
+	test_dynamic_logging
+	rm ${ERR_LOG}
+}
+
+
+# main
+
+rediscover_target Prometheus


### PR DESCRIPTION
Add automation tests for dynamic log change feature (https://github.com/turbonomic/kubeturbo/pull/900). The test performs the following: 
1. Create ns
2. Install prometurbo through operator
~~3. Rediscover in case discovery is not initiated in time.~~
4. Check prometurbo pod to make sure deployment is successful.
5. Change log level by updating CR (spec.logging.level)
6. Look for msg "Logging level is changed from 2 to 4"
7. Check pod doesn't restart and old logs are preserved
8. Check that cm is updated
~~9. Rediscover to generate new logs~~
~~10. Check pod logs again to make sure logs with correct loglevel are showing up.~~

Logs for test run:

```
OPERATOR_IMAGE_VERSION=8.9.5-SNAPSHOT PROMETURBO_IMAGE_VERSION=8.9.5-SNAPSHOT bash ./test.sh
> Running dynamic logging tests
namespace/turbo created
customresourcedefinition.apiextensions.k8s.io/prometurbos.charts.helm.k8s.io unchanged
serviceaccount/prometurbo-operator created
clusterrolebinding.rbac.authorization.k8s.io/prometurbo-operator created
clusterrole.rbac.authorization.k8s.io/prometurbo-operator unchanged
deployment.apps/prometurbo-operator created
> Start testing for Deploy prometurbo for dynamic logging
prometurbo.charts.helm.k8s.io/prometurbo-testcr1 created
Wait for 60s to finish container creation
>  Deployment deployment.apps/prometurbo-testcr1 cr check........PASSED
>  ClusterRoleBinding prometurbo-binding-prometurbo-testcr1-turbo check........PASSED
>  ClusterRole cluster-admin check........PASSED
> Deploy prometurbo for dynamic logging........PASSED
-------------Pod log before-----------------------------------------
I0725 16:56:18.236849       1 prometurbo.go:87] Running prometurbo GIT_COMMIT: 
I0725 16:56:18.237867       1 prometurbo.go:93] Number of concurrent workers to discover metrics: 4
I0725 16:56:18.238198       1 provider.go:37] Metrics config file /etc/prometurbo/prometheus.config does not exist.
I0725 16:56:18.237266       1 prometurbo.go:170] Start watching the autoreload config file /etc/prometurbo/turbo-autoreload.config
I0725 16:56:18.284204       1 businessapp_config.go:33] Read business application configuration from /etc/prometurbo/businessapp.config
I0725 16:56:18.284324       1 businessapp_config.go:38] # This configuration defines business applications and their associated business transactions
# and dependent services.
#
# [Schema]
# businessApplications: [ businessApplication ]
# businessApplication:
#   name: string                   # The name of the business application. Required.
#   from: string                   # The discovering source (target URL) of the business application. Required.
#   transactions: [ transaction ]  # A list of business transactions. Optional.
#   services: [ string ]           # A list of services that the business application depends on. Required.
# transaction:
#   name: string                   # The display name of the transaction. Optional.
#   path: string                   # The request path of a business transaction. Required.
#   dependOn: [ string ]           # The list of services that the business transaction depends on. Required.
businessApplications:
I0725 16:56:18.284459       1 businessapp_config.go:46] No business application is configured.
I0725 16:56:18.284481       1 prometurbo.go:147] Business application topology configuration: ([]config.BusinessApplication) <nil>
I0725 16:56:18.284537       1 server.go:73] HTTP server listens on: 10.42.0.14:8081
I0725 16:56:19.752447       1 provider.go:50] Unable to list PrometheusQueryMapping resource: no matches for kind "PrometheusQueryMapping" in version "metrics.turbonomic.io/v1alpha1".
I0725 16:56:19.752513       1 handler.go:156] Total discovery tasks to dispatch 0.
I0725 16:56:19.752542       1 collector.go:38] Collected results from all 0 tasks.
I0725 16:56:19.752551       1 handler.go:165] Discovered 0 entities.
-------------End Pod log before-----------------------------------------
Updating CR to add logging level...
prometurbo.charts.helm.k8s.io/prometurbo-testcr1 configured
Wait for 10s for log level changes to be reflected...
I0725 16:57:23.629217 1 prometurbo.go:182] Logging level is changed from 2 to 4
-------------Pod log after-----------------------------------------
I0725 16:56:18.236849       1 prometurbo.go:87] Running prometurbo GIT_COMMIT: 
I0725 16:56:18.237867       1 prometurbo.go:93] Number of concurrent workers to discover metrics: 4
I0725 16:56:18.238198       1 provider.go:37] Metrics config file /etc/prometurbo/prometheus.config does not exist.
I0725 16:56:18.237266       1 prometurbo.go:170] Start watching the autoreload config file /etc/prometurbo/turbo-autoreload.config
I0725 16:56:18.284204       1 businessapp_config.go:33] Read business application configuration from /etc/prometurbo/businessapp.config
I0725 16:56:18.284324       1 businessapp_config.go:38] # This configuration defines business applications and their associated business transactions
# and dependent services.
#
# [Schema]
# businessApplications: [ businessApplication ]
# businessApplication:
#   name: string                   # The name of the business application. Required.
#   from: string                   # The discovering source (target URL) of the business application. Required.
#   transactions: [ transaction ]  # A list of business transactions. Optional.
#   services: [ string ]           # A list of services that the business application depends on. Required.
# transaction:
#   name: string                   # The display name of the transaction. Optional.
#   path: string                   # The request path of a business transaction. Required.
#   dependOn: [ string ]           # The list of services that the business transaction depends on. Required.
businessApplications:
I0725 16:56:18.284459       1 businessapp_config.go:46] No business application is configured.
I0725 16:56:18.284481       1 prometurbo.go:147] Business application topology configuration: ([]config.BusinessApplication) <nil>
I0725 16:56:18.284537       1 server.go:73] HTTP server listens on: 10.42.0.14:8081
I0725 16:56:19.752447       1 provider.go:50] Unable to list PrometheusQueryMapping resource: no matches for kind "PrometheusQueryMapping" in version "metrics.turbonomic.io/v1alpha1".
I0725 16:56:19.752513       1 handler.go:156] Total discovery tasks to dispatch 0.
I0725 16:56:19.752542       1 collector.go:38] Collected results from all 0 tasks.
I0725 16:56:19.752551       1 handler.go:165] Discovered 0 entities.
I0725 16:57:23.629217       1 prometurbo.go:182] Logging level is changed from 2 to 4
-------------End Pod log after-----------------------------------------
Cleanup...
prometurbo.charts.helm.k8s.io "prometurbo-testcr1" deleted
deployment.apps "prometurbo-operator" deleted
clusterrolebinding.rbac.authorization.k8s.io "prometurbo-operator" deleted
serviceaccount "prometurbo-operator" deleted
namespace "turbo" deleted
Test passed!

```


