### PR TITLE
[TRB-45491]Prometurbo certified operator automation to add dependencies needed by script

### DIFF
--- a/deploy/prometurbo-operator/Makefile
+++ b/deploy/prometurbo-operator/Makefile
@@ -187,11 +187,8 @@ OPERATOR_CRD_FILE_PATH ?= deploy/crds/charts.helm.k8s.io_prometurbos_crd.yaml
 CLUSTER_PERMISSION_ROLE_YAML_FILE_PATH ?= deploy/prometurbo-operator-cluster-role.yaml
 CERTIFIED_OPERATOR_CLUSTER_SERVICE_VERSION_YAML_FILE_PATH ?= $(OPERATOR_BUNDLE_DIR)/manifest/prometurbo-certified.clusterserviceversion.yaml
 GITHUB_REPO_URL := https://api.github.com/repos/turbodeploy/certified-operators/contents/operators/prometurbo-certified
-ifndef ACCESS_TOKEN
-$(error ACCESS_TOKEN is missing. It is required to verify the release versions from Git. Please provide the ACCESS_TOKEN to proceed with the release of the certified operator bundle.)
-endif
 OPERATOR_VERSION_BETA := $(shell \
-	OPERATOR_BETA_RELEASE_MINOR_VERSION=$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | \
+	OPERATOR_BETA_RELEASE_MINOR_VERSION=$$(curl -s "$(GITHUB_REPO_URL)" | \
 	jq -r 'map(select(.type == "dir")) | .[].name | match("$(OPERATOR_RELEASE_VERSION)-beta\\.[0-9]+") | try .string catch "0"' | \
 	awk -F'.' 'BEGIN{max=0} {n=substr($$0, index($$0, "beta.")+5)+0; if (n>max) max=n} END{print max}'); \
 	if [ -z "$$OPERATOR_BETA_RELEASE_MINOR_VERSION" ]; then \
@@ -213,7 +210,7 @@ verify-operator-release-channel:
 verify-stable-operator-release-version:
 	if [ "$(OPERATOR_RELEASE_CHANNEL)" = "stable" ]; then \
         echo "Checking if the stable release version $(OPERATOR_RELEASE_VERSION) exists..."; \
-         if [ -n "$$(curl -H "Authorization: Bearer $(ACCESS_TOKEN)" -s "$(GITHUB_REPO_URL)" | jq -r 'map(select(.type == "dir" and .name == "$(OPERATOR_RELEASE_VERSION)")) | .[].name')" ]; then \
+         if [ -n "$$(curl -s "$(GITHUB_REPO_URL)" | jq -r 'map(select(.type == "dir" and .name == "$(OPERATOR_RELEASE_VERSION)")) | .[].name')" ]; then \
             echo "Error: The operator release version already exists for stable channel: $(OPERATOR_RELEASE_VERSION)."; \
             exit 1; \
         fi; \

--- a/deploy/prometurbo-operator/bundle-template/cluster_permissions_automation.py
+++ b/deploy/prometurbo-operator/bundle-template/cluster_permissions_automation.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python
-import ruamel.yaml
 import sys
+import subprocess
+def install_ruamel_yaml():
+  version = "0.17.32"
+  subprocess.check_call([sys.executable, '-m', 'pip', 'install', f'ruamel.yaml=={version}'])
+
+# Check if ruamel.yaml is installed. If not, install it.
+try:
+    import ruamel.yaml
+except ImportError:
+    install_ruamel_yaml()
+    import ruamel.yaml
 
 ## Utility function to update the cluster permission roles into target csv file
 def insert_fields(cluster_permission_role_yaml, certified_operator_cluster_service_version_yaml):


### PR DESCRIPTION
# Intent
- To update cluster role permissions in the CSV file, we utilize the ruamel Python library. This library must be installed in the Python environment for the script to execute successfully.
- Removal of Access token  usage for GitHub API call

# Background

- The import of this library was previously unsuccessful because the installation step was omitted. With this modification, the system will verify if there's a problem importing the library. If an issue arises, it will then install the library into the Python environment, ensuring the script runs successfully.
- The reason for removing the Access Token in the GitHub API call is multifaceted. Firstly, we intend to globalize the validation of the Access Token, allowing other variables to utilize it. Its current setup inadvertently impacts other make commands, as they incorrectly expect the presence of a token. Furthermore, the GitHub API's rate limit for unauthorized requests stands at 60 requests per hour. In practical scenarios, this limit should be enough to support our processes.

# Testing

Before:

![Screenshot 2023-08-09 at 1 19 16 PM (2)](https://github.com/turbonomic/prometurbo/assets/112518353/3d5ee40d-39c8-4ac9-bc0e-4574c5e3452f)

After

![Screenshot 2023-08-09 at 1 23 58 PM (2)](https://github.com/turbonomic/prometurbo/assets/112518353/ca23349a-fc9f-4358-b854-0a137a720b1c)


