### PR TITLE
[TRB-46035] bug fix changes to eliminate piping issue and space issue due to ruamel version

### DIFF
--- a/deploy/prometurbo-operator/Makefile
+++ b/deploy/prometurbo-operator/Makefile
@@ -186,7 +186,7 @@ OPERATOR_BUNDLE_TEMPLATE_DIR ?= bundle-template
 OPERATOR_CRD_FILE_PATH ?= deploy/crds/charts.helm.k8s.io_prometurbos_crd.yaml
 CLUSTER_PERMISSION_ROLE_YAML_FILE_PATH ?= deploy/prometurbo-operator-cluster-role.yaml
 CERTIFIED_OPERATOR_CLUSTER_SERVICE_VERSION_YAML_FILE_PATH ?= $(OPERATOR_BUNDLE_DIR)/manifest/prometurbo-certified.clusterserviceversion.yaml
-GITHUB_REPO_URL := https://api.github.com/repos/turbodeploy/certified-operators/contents/operators/prometurbo-certified
+GITHUB_REPO_URL := https://api.github.com/repos/turbonomic/certified-operators/contents/operators/prometurbo-certified
 OPERATOR_VERSION_BETA := $(shell \
 	OPERATOR_BETA_RELEASE_MINOR_VERSION=$$(curl -s "$(GITHUB_REPO_URL)" | \
 	jq -r 'map(select(.type == "dir")) | .[].name | match("$(OPERATOR_RELEASE_VERSION)-beta\\.[0-9]+") | try .string catch "0"' | \
@@ -260,15 +260,16 @@ update_operator_version_in_operator_bundle:
 	@echo "Updating release versions in $(OPERATOR_CERTIFIED)-clusterserviceversion..."
 	$(eval OPERATOR_RELEASE_CHANNEL_VERSION := $(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION)))
 	$(YQ) eval -i '.metadata.name |= sub("prometurbo-operator.v.*", "prometurbo-operator.v$(OPERATOR_RELEASE_CHANNEL_VERSION)") | .spec.version = "$(OPERATOR_RELEASE_CHANNEL_VERSION)"' \
-		$(OPERATOR_BUNDLE_DIR)/manifest/$(OPERATOR_CERTIFIED).clusterserviceversion.yaml
+	$(OPERATOR_BUNDLE_DIR)/manifest/$(OPERATOR_CERTIFIED).clusterserviceversion.yaml
 	@echo "$(OPERATOR_CERTIFIED)-clusterserviceversion release versions updated successfully."
 
 ## update skipRange based on inclusive and exclusive release versions set
 update_olm_skipRange_in_operator_bundle:
 	@echo "Updating olm.skipRange in $(OPERATOR_CERTIFIED)-clusterserviceversion..."
-	$(YQ) eval -i '.metadata.annotations."olm.skipRange" |= sub(">=[^<]+", ">=$(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION)-$(OPERATOR_OLM_INCLUSIVE_BETA_VERSION),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION))") \
-	| .metadata.annotations."olm.skipRange" |= sub("<[^<]+", " <$(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION))")' \
-	   $(OPERATOR_BUNDLE_DIR)/manifest/$(OPERATOR_CERTIFIED).clusterserviceversion.yaml
+	$(eval OLMRANGE_LOWER_BOUND := $(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION)-$(OPERATOR_OLM_INCLUSIVE_BETA_VERSION),$(OPERATOR_OLM_INCLUSIVE_RANGE_VERSION)))
+	$(eval OLMRANGE_UPPER_BOUND := $(if $(filter $(OPERATOR_BETA_RELEASE_FILTER),$(OPERATOR_RELEASE_CHANNEL)),$(OPERATOR_RELEASE_VERSION)-$(OPERATOR_VERSION_BETA),$(OPERATOR_RELEASE_VERSION)))
+	$(YQ) eval -i '.metadata.annotations."olm.skipRange" |= sub(">=[^<]+", ">=$(OLMRANGE_LOWER_BOUND)") | .metadata.annotations."olm.skipRange" |= sub("<[^<]+", " <$(OLMRANGE_UPPER_BOUND)")' \
+	$(OPERATOR_BUNDLE_DIR)/manifest/$(OPERATOR_CERTIFIED).clusterserviceversion.yaml
 	@echo "$(OPERATOR_CERTIFIED)-clusterserviceversion olm.skipRange updated successfully."
 
 ## update cluster permissions roles
@@ -283,7 +284,7 @@ update_cluster_permissions_in_operator_bundle:
 update_release_channel_in_operator_bundle:
 	@echo "Updating release channel in  $(OPERATOR_CERTIFIED)-annotations..."
 	$(YQ) eval -i '.annotations."operators.operatorframework.io.bundle.channels.v1" = "$(OPERATOR_RELEASE_CHANNEL)"' \
-		$(OPERATOR_BUNDLE_DIR)/metadata/annotations.yaml
+	$(OPERATOR_BUNDLE_DIR)/metadata/annotations.yaml
 	@echo "$(OPERATOR_CERTIFIED)-annotations release channel updated successfully."
 
 

--- a/deploy/prometurbo-operator/bundle-template/cluster_permissions_automation.py
+++ b/deploy/prometurbo-operator/bundle-template/cluster_permissions_automation.py
@@ -2,7 +2,7 @@
 import sys
 import subprocess
 def install_ruamel_yaml():
-  version = "0.17.32"
+  version = "0.16.12"
   subprocess.check_call([sys.executable, '-m', 'pip', 'install', f'ruamel.yaml=={version}'])
 
 # Check if ruamel.yaml is installed. If not, install it.


### PR DESCRIPTION
https://jsw.ibm.com/browse/TRB-46035

# Intent
**Prometurbo Certified Operator Automation Bug**
Issue with Updating olm.skipRange in Makefile Rule and ruamel version creating spacing issues when modifying csv

# Background

- **Incorrect Pipe Handling**: In the original Makefile rule, the pipe (|) used for chaining yq commands wasn't properly escaped. This was caught only when running the script through Jenkins
- Ruamel.yaml version 0.17.32 is introducing extra spacing when replacing lengthy lines, hence opting to change to version 0.16.12, which maintains the original indentation for lengthy lines when updating csv


**Solution:**

- separated the computations for olm.skipRange values. The eval function was used to define OLMSKIP_LOWER_BOUND and OLMSKIP_UPPER_BOUND variables ahead of the main command.
- single, yq call. This command updates both parts of the olm.skipRange in sequence.
- Update ruamel version used in the make rule to update cluster role permissions

# Testing

The issue on Jenkins:
<img width="1299" alt="Screenshot 2023-08-16 at 2 16 37 PM" src="https://github.com/turbonomic/kubeturbo/assets/112518353/e8fc64b0-aef1-4c46-920a-e1f4d0aea96d">

Jenkins log successfully executing the operation:
![Screenshot 2023-08-16 at 3 50 42 PM](https://github.com/turbonomic/kubeturbo/assets/112518353/aed37b27-dbb0-4804-b3ae-7e22f5f3b4ac)

Spacing Issue Fix in csv:
![Screenshot 2023-08-16 at 10 32 36 PM](https://github.com/turbonomic/prometurbo/assets/112518353/6916d6b1-8608-407b-abc2-904db3b24289)

Release of Operator into redhat-openshift-ecosystem/certified-operators - 8.9.6

![Screenshot 2023-08-16 at 10 41 57 PM](https://github.com/turbonomic/prometurbo/assets/112518353/a2049022-c292-4aeb-87db-f8945200dfdc)

![Screenshot 2023-08-16 at 11 18 36 PM](https://github.com/turbonomic/prometurbo/assets/112518353/e91c313f-d2b7-4523-aa8c-6c340e06cd60)


