### PR TITLE
 [TRB-46400]: Upgrade go version to 1.20.7 to fix CVE-2023-39533

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 go:
-  - 1.20.5
+  - 1.20.7
 
 go_import_path: github.com/turbonomic/prometurbo
 

--- a/build/Dockerfile.multi-archs
+++ b/build/Dockerfile.multi-archs
@@ -1,5 +1,5 @@
 # Building base image
-FROM --platform=$BUILDPLATFORM golang:1.20.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7 AS builder
 ARG VERSION TARGETOS TARGETARCH
 ENV PROMETURBO_VERSION $VERSION
 WORKDIR /workspace
@@ -7,7 +7,6 @@ ADD . ./
 RUN make multi-archs
 
 FROM registry.access.redhat.com/ubi8-minimal
-MAINTAINER Turbonomic <turbodeploy@turbonomic.com>
 ARG GIT_COMMIT
 ARG TARGETPLATFORM
 ENV GIT_COMMIT ${GIT_COMMIT}


### PR DESCRIPTION
Intent

Upgrade go version
to fix [CVE-2023-39533](https://cve.circl.lu/cve/CVE-2023-39533)

Testing

Build dev image with the changes and scan it with twistlock, vulnerability issue resolved
[twistlock-scan-results-20230825-033603-259610000-UTC-1247E771.results.csv](https://github.com/turbonomic/prometurbo/files/12435354/twistlock-scan-results-20230825-033603-259610000-UTC-1247E771.results.csv)
