### PR TITLE
[TRB-46808]: Removed coveralls integration from travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - make fmtcheck
   - make vet
   - make product
+  - make test
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,10 @@ go:
 
 go_import_path: github.com/turbonomic/prometurbo
 
-before_install:
-  - go install -v github.com/mattn/goveralls@HEAD
-
 script:
   - make fmtcheck
   - make vet
   - make product
-  - $HOME/gopath/bin/goveralls -v -race -service=travis-ci
 
 after_success:
   - |


### PR DESCRIPTION
# Intent

Remove coveralls integrations from Travis builds.

# Background

Coveralls is free for public repositories, but requires licenses for private/enterprise repos. Since we are moving to IBM enterprise Git, we need to remove this integration. We should be able to capture code coverage using SonarQube, or some other approved, tool in the future. 

# Testing

N/A - will test enterprise build after merging.